### PR TITLE
fix: bind terminal-server to 0.0.0.0 so WSL2 localhost forwarding rea…

### DIFF
--- a/dashboard/terminal-server/src/server.js
+++ b/dashboard/terminal-server/src/server.js
@@ -300,7 +300,7 @@ class TerminalServer {
     this.wss.on('connection', (ws, req) => this.handleWebSocketConnection(ws, req));
 
     return new Promise((resolve, reject) => {
-      server.listen(this.port, (err) => {
+      server.listen(this.port, '0.0.0.0', (err) => {
         if (err) return reject(err);
         this.server = server;
         resolve(server);


### PR DESCRIPTION
…ches it

Node's `server.listen(port)` with no host arg binds to `::` (IPv6 unspecified) when IPv6 is available, creating a dual-stack socket. On most Linux systems this also accepts IPv4 connections, but WSL2's automatic localhost forwarding only mirrors IPv4 binds from WSL2 into the Windows loopback. Dual-stack/IPv6 binds aren't forwarded, so from a Windows browser `http://127.0.0.1:32352` can't reach terminal-server even though `curl` works fine from inside WSL2.

The dashboard's Flask backend already binds explicitly to `0.0.0.0`, which is why the dashboard itself loads on WSL2 but the in-browser terminal (and agent chat) silently fail to connect.

Pass `'0.0.0.0'` as the host arg to match Flask's behaviour. No-op on macOS and native Linux; fixes the reachability gap on WSL2.

## Summary by Sourcery

Bug Fixes:
- Fix terminal-server and related WebSocket features being inaccessible from the Windows host when running under WSL2 by explicitly binding to 0.0.0.0.