### PR TITLE
feat: paste screenshots from clipboard into agent chat

### DIFF
--- a/dashboard/frontend/src/components/AgentChat.tsx
+++ b/dashboard/frontend/src/components/AgentChat.tsx
@@ -600,6 +600,28 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
     }
   }, [processFiles])
 
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    const imageFiles: File[] = []
+    for (const item of items) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        const file = item.getAsFile()
+        if (file) {
+          const ext = file.type.split('/')[1] || 'png'
+          const named = file.name && file.name !== 'image.png'
+            ? file
+            : new File([file], `pasted-${Date.now()}.${ext}`, { type: file.type })
+          imageFiles.push(named)
+        }
+      }
+    }
+    if (imageFiles.length > 0) {
+      e.preventDefault()
+      processFiles(imageFiles)
+    }
+  }, [processFiles])
+
   // Send message
   const sendMessage = useCallback(async () => {
     const text = input.trim()
@@ -1119,6 +1141,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
               value={input}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
               placeholder={`Message @${agent}...`}
               rows={1}
               className="flex-1 resize-none bg-transparent text-sm text-[#e6edf3] placeholder:text-[#667085] focus:outline-none max-h-32 disabled:cursor-not-allowed disabled:opacity-60"


### PR DESCRIPTION
## Summary
- Adds an `onPaste` handler on the agent chat textarea that pulls image items off the clipboard and routes them through the existing file-attachment pipeline.
- Pasted images get a `pasted-{ts}.{ext}` filename so the terminal-server temp-file write and base64 round-trip keep working unchanged.
- Plain-text pastes fall through to default browser behavior — no regression.

Brings the chat composer to parity with ChatGPT/Gemini for screenshot workflows. Frontend-only change; backend (`server.js` / `chat-bridge.js`) already supports `files[]` on `chat_send`.

## Test plan
- [ ] `cd dashboard/frontend && npx tsc --noEmit` clean
- [ ] Take a screenshot, focus the chat textarea, Cmd/Ctrl+V → image preview appears above the input
- [ ] Send the message → agent receives the file via the existing Read-tool flow
- [ ] Paste plain text → still pastes as text, no image attached
- [ ] Paste a copied PNG from a file manager → attaches with original filename

## Summary by Sourcery

New Features:
- Support pasting screenshots and other clipboard images into the agent chat textarea as file attachments.