### PR TITLE
feat: chat message rewind, inline edit, and copy

### DIFF
--- a/dashboard/frontend/src/components/AgentChat.tsx
+++ b/dashboard/frontend/src/components/AgentChat.tsx
@@ -7,6 +7,7 @@ import {
   FileCode, Terminal as TermIcon, CheckCircle2,
   Paperclip, X, File as FileIcon, ImageIcon, Upload,
   Ticket as TicketIcon, Plus, ShieldAlert, Check, Ban,
+  Pencil,
 } from 'lucide-react'
 
 interface SkillItem {
@@ -61,9 +62,9 @@ interface FileRef {
 }
 
 type ChatMessage =
-  | { role: 'user'; text: string; files?: FileRef[]; ts: number }
-  | { role: 'assistant'; blocks: AssistantBlock[]; ts: number; streaming?: boolean }
-  | { role: 'system'; text: string; ts: number }
+  | { role: 'user'; text: string; files?: FileRef[]; ts: number; uuid?: string }
+  | { role: 'assistant'; blocks: AssistantBlock[]; ts: number; streaming?: boolean; uuid?: string }
+  | { role: 'system'; text: string; ts: number; uuid?: string }
 
 type AssistantBlock =
   | { type: 'text'; text: string }
@@ -89,6 +90,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
     open: false, query: '', items: [], selectedIndex: 0, anchorStart: -1,
   })
   const [pendingApprovals, setPendingApprovals] = useState<PermissionRequest[]>([])
+  const [rewindRequest, setRewindRequest] = useState<{ fromUuid: string } | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -158,10 +160,11 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
 
         switch (msg.type) {
           case 'session_joined':
-            // Restore chat history from server
+            // Restore chat history from server — preserve uuid from each message
             if (msg.chatHistory && msg.chatHistory.length > 0) {
               setMessages(msg.chatHistory.map((m: any) => ({
                 ...m,
+                uuid: m.uuid,
                 streaming: false,
               })))
               scrollToBottom()
@@ -600,6 +603,25 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
     }
   }, [processFiles])
 
+  // Pencil button: stage a rewind for the given user message
+  const stageRewind = useCallback((msg: ChatMessage) => {
+    if (msg.role !== 'user') return
+    setRewindRequest({ fromUuid: msg.uuid! })
+    setInput(msg.text)
+    requestAnimationFrame(() => {
+      if (inputRef.current) {
+        inputRef.current.focus()
+        inputRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    })
+  }, [])
+
+  // Cancel a staged rewind
+  const cancelRewind = useCallback(() => {
+    setRewindRequest(null)
+    setInput('')
+  }, [])
+
   // Send message
   const sendMessage = useCallback(async () => {
     const text = input.trim()
@@ -623,29 +645,53 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
       })
     }
 
-    setMessages(prev => [...prev, {
-      role: 'user',
-      text,
-      files: fileMeta.length > 0 ? fileMeta : undefined,
-      ts: Date.now(),
-    }])
+    // Capture rewindRequest before clearing state
+    const pendingRewind = rewindRequest
+
+    if (pendingRewind) {
+      // Optimistic truncation: drop messages from rewindFromUuid onward
+      setMessages(prev => {
+        const cutIdx = prev.findIndex(m => m.uuid === pendingRewind.fromUuid)
+        const base = cutIdx !== -1 ? prev.slice(0, cutIdx) : prev
+        return [...base, {
+          role: 'user' as const,
+          text,
+          files: fileMeta.length > 0 ? fileMeta : undefined,
+          ts: Date.now(),
+        }]
+      })
+    } else {
+      setMessages(prev => [...prev, {
+        role: 'user' as const,
+        text,
+        files: fileMeta.length > 0 ? fileMeta : undefined,
+        ts: Date.now(),
+      }])
+    }
+
     setInput('')
     setAttachedFiles([])
+    setRewindRequest(null)
     setStatus('running')
     setErrorMsg(null)
 
-    wsRef.current.send(JSON.stringify({
+    const payload: Record<string, unknown> = {
       type: 'chat_send',
       prompt: text,
       files: filesForServer.length > 0 ? filesForServer : undefined,
-    }))
+    }
+    if (pendingRewind) {
+      payload.rewindFromUuid = pendingRewind.fromUuid
+    }
+
+    wsRef.current.send(JSON.stringify(payload))
 
     scrollToBottom()
     if (inputRef.current) {
       inputRef.current.style.height = 'auto'
       inputRef.current.focus()
     }
-  }, [input, attachedFiles, scrollToBottom])
+  }, [input, attachedFiles, scrollToBottom, rewindRequest])
 
   // Detect slash-command region from caret position
   const detectSlash = useCallback((text: string, caret: number) => {
@@ -909,7 +955,17 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
         {messages.map((msg, i) => (
           <div key={i}>
             {msg.role === 'user' && (
-              <div className="flex justify-end">
+              <div className="flex justify-end group/usermsg items-end gap-2">
+                {/* Hover-revealed pencil button — only when uuid is present and not running */}
+                {msg.uuid && status !== 'running' && (
+                  <button
+                    onClick={() => stageRewind(msg)}
+                    className="opacity-0 group-hover/usermsg:opacity-100 transition-opacity flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                    title="Edit message"
+                  >
+                    <Pencil size={12} />
+                  </button>
+                )}
                 <div className="max-w-[70%] space-y-2">
                   {/* File attachments in bubble */}
                   {(msg as any).files && (msg as any).files.length > 0 && (
@@ -1009,6 +1065,20 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
       {/* Input area */}
       <div className="flex-shrink-0 border-t border-[#21262d] bg-[#0d1117] px-4 py-3">
         <div className="max-w-3xl mx-auto space-y-2">
+          {/* Editing-message pill */}
+          {rewindRequest && (
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#21262d] bg-[#161b22] text-[11px] text-[#e6edf3]">
+              <Pencil size={11} className="text-[#667085] flex-shrink-0" />
+              <span className="flex-1">Editing message — previous responses will be removed</span>
+              <button
+                onClick={cancelRewind}
+                className="flex-shrink-0 text-[#667085] hover:text-[#e6edf3] transition-colors"
+                title="Cancel edit"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          )}
           {/* File previews */}
           {attachedFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-1">

--- a/dashboard/frontend/src/components/AgentChat.tsx
+++ b/dashboard/frontend/src/components/AgentChat.tsx
@@ -7,7 +7,7 @@ import {
   FileCode, Terminal as TermIcon, CheckCircle2,
   Paperclip, X, File as FileIcon, ImageIcon, Upload,
   Ticket as TicketIcon, Plus, ShieldAlert, Check, Ban,
-  Pencil,
+  Pencil, Copy,
 } from 'lucide-react'
 
 interface SkillItem {
@@ -90,7 +90,9 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
     open: false, query: '', items: [], selectedIndex: 0, anchorStart: -1,
   })
   const [pendingApprovals, setPendingApprovals] = useState<PermissionRequest[]>([])
-  const [rewindRequest, setRewindRequest] = useState<{ fromUuid: string } | null>(null)
+  const [editingUuid, setEditingUuid] = useState<string | null>(null)
+  const [editingText, setEditingText] = useState('')
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -603,24 +605,67 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
     }
   }, [processFiles])
 
-  // Pencil button: stage a rewind for the given user message
-  const stageRewind = useCallback((msg: ChatMessage) => {
-    if (msg.role !== 'user') return
-    setRewindRequest({ fromUuid: msg.uuid! })
-    setInput(msg.text)
-    requestAnimationFrame(() => {
-      if (inputRef.current) {
-        inputRef.current.focus()
-        inputRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-      }
-    })
+  // Extract plain text from a message for copying
+  const getMessageText = (msg: ChatMessage): string => {
+    if (msg.role === 'user' || msg.role === 'system') return msg.text
+    return msg.blocks
+      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+      .map(b => b.text)
+      .join('\n\n')
+  }
+
+  // Copy a message to clipboard with brief visual feedback
+  const copyMessage = useCallback((msg: ChatMessage, idx: number) => {
+    const text = getMessageText(msg)
+    if (!text) return
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedIndex(idx)
+      setTimeout(() => setCopiedIndex(prev => prev === idx ? null : prev), 1500)
+    }).catch(() => {})
   }, [])
 
-  // Cancel a staged rewind
-  const cancelRewind = useCallback(() => {
-    setRewindRequest(null)
-    setInput('')
+  // Pencil button: enter inline edit mode for the given user message
+  const startEdit = useCallback((msg: ChatMessage) => {
+    if (msg.role !== 'user' || !msg.uuid) return
+    setEditingUuid(msg.uuid)
+    setEditingText(msg.text)
   }, [])
+
+  // Cancel inline edit
+  const cancelEdit = useCallback(() => {
+    setEditingUuid(null)
+    setEditingText('')
+  }, [])
+
+  // Commit inline edit — truncates messages from edit point and sends rewind
+  const commitEdit = useCallback(() => {
+    const text = editingText.trim()
+    const uuid = editingUuid
+    if (!text || !uuid || !wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return
+
+    setMessages(prev => {
+      const cutIdx = prev.findIndex(m => m.uuid === uuid)
+      const base = cutIdx !== -1 ? prev.slice(0, cutIdx) : prev
+      return [...base, {
+        role: 'user' as const,
+        text,
+        ts: Date.now(),
+      }]
+    })
+
+    setEditingUuid(null)
+    setEditingText('')
+    setStatus('running')
+    setErrorMsg(null)
+
+    wsRef.current.send(JSON.stringify({
+      type: 'chat_send',
+      prompt: text,
+      rewindFromUuid: uuid,
+    }))
+
+    scrollToBottom()
+  }, [editingText, editingUuid, scrollToBottom])
 
   // Send message
   const sendMessage = useCallback(async () => {
@@ -645,53 +690,30 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
       })
     }
 
-    // Capture rewindRequest before clearing state
-    const pendingRewind = rewindRequest
-
-    if (pendingRewind) {
-      // Optimistic truncation: drop messages from rewindFromUuid onward
-      setMessages(prev => {
-        const cutIdx = prev.findIndex(m => m.uuid === pendingRewind.fromUuid)
-        const base = cutIdx !== -1 ? prev.slice(0, cutIdx) : prev
-        return [...base, {
-          role: 'user' as const,
-          text,
-          files: fileMeta.length > 0 ? fileMeta : undefined,
-          ts: Date.now(),
-        }]
-      })
-    } else {
-      setMessages(prev => [...prev, {
-        role: 'user' as const,
-        text,
-        files: fileMeta.length > 0 ? fileMeta : undefined,
-        ts: Date.now(),
-      }])
-    }
+    setMessages(prev => [...prev, {
+      role: 'user' as const,
+      text,
+      files: fileMeta.length > 0 ? fileMeta : undefined,
+      ts: Date.now(),
+    }])
 
     setInput('')
     setAttachedFiles([])
-    setRewindRequest(null)
     setStatus('running')
     setErrorMsg(null)
 
-    const payload: Record<string, unknown> = {
+    wsRef.current.send(JSON.stringify({
       type: 'chat_send',
       prompt: text,
       files: filesForServer.length > 0 ? filesForServer : undefined,
-    }
-    if (pendingRewind) {
-      payload.rewindFromUuid = pendingRewind.fromUuid
-    }
-
-    wsRef.current.send(JSON.stringify(payload))
+    }))
 
     scrollToBottom()
     if (inputRef.current) {
       inputRef.current.style.height = 'auto'
       inputRef.current.focus()
     }
-  }, [input, attachedFiles, scrollToBottom, rewindRequest])
+  }, [input, attachedFiles, scrollToBottom])
 
   // Detect slash-command region from caret position
   const detectSlash = useCallback((text: string, caret: number) => {
@@ -954,18 +976,70 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
 
         {messages.map((msg, i) => (
           <div key={i}>
-            {msg.role === 'user' && (
-              <div className="flex justify-end group/usermsg items-end gap-2">
-                {/* Hover-revealed pencil button — only when uuid is present and not running */}
-                {msg.uuid && status !== 'running' && (
+            {msg.role === 'user' && editingUuid && msg.uuid === editingUuid && (
+              <div className="flex justify-end">
+                <div className="w-full max-w-[85%] rounded-2xl border bg-[#1a2744] px-3 py-2" style={{ borderColor: accentColor + '60' }}>
+                  <textarea
+                    value={editingText}
+                    onChange={(e) => setEditingText(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') {
+                        e.preventDefault()
+                        cancelEdit()
+                      } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                        e.preventDefault()
+                        commitEdit()
+                      }
+                    }}
+                    autoFocus
+                    rows={Math.min(10, Math.max(2, editingText.split('\n').length))}
+                    className="w-full bg-transparent text-sm text-[#e6edf3] placeholder:text-[#667085] focus:outline-none resize-none"
+                  />
+                  <div className="flex justify-end gap-2 mt-2 pt-2 border-t border-[#21262d]">
+                    <button
+                      onClick={cancelEdit}
+                      className="px-3 py-1 rounded-md text-xs text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#21262d] transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={commitEdit}
+                      disabled={!editingText.trim()}
+                      className="px-3 py-1 rounded-md text-xs border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      style={{
+                        borderColor: `${accentColor}40`,
+                        background: `${accentColor}15`,
+                        color: accentColor,
+                      }}
+                    >
+                      Send
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {msg.role === 'user' && !(editingUuid && msg.uuid === editingUuid) && (
+              <div className="flex justify-end group/usermsg items-end gap-1">
+                {/* Hover-revealed action buttons */}
+                <div className="flex items-center gap-0.5 opacity-0 group-hover/usermsg:opacity-100 transition-opacity mr-1">
                   <button
-                    onClick={() => stageRewind(msg)}
-                    className="opacity-0 group-hover/usermsg:opacity-100 transition-opacity flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
-                    title="Edit message"
+                    onClick={() => copyMessage(msg, i)}
+                    className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                    title={copiedIndex === i ? 'Copied' : 'Copy message'}
                   >
-                    <Pencil size={12} />
+                    {copiedIndex === i ? <Check size={12} className="text-[#00FFA7]" /> : <Copy size={12} />}
                   </button>
-                )}
+                  {msg.uuid && status !== 'running' && !editingUuid && (
+                    <button
+                      onClick={() => startEdit(msg)}
+                      className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                      title="Edit message"
+                    >
+                      <Pencil size={12} />
+                    </button>
+                  )}
+                </div>
                 <div className="max-w-[70%] space-y-2">
                   {/* File attachments in bubble */}
                   {(msg as any).files && (msg as any).files.length > 0 && (
@@ -1001,7 +1075,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
             )}
 
             {msg.role === 'assistant' && (
-              <div className="flex gap-3">
+              <div className="flex gap-3 group/asstmsg">
                 <div className="flex-shrink-0 mt-0.5">
                   <AgentAvatar name={agent} size={28} />
                 </div>
@@ -1025,6 +1099,18 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                     return !hasVisibleContent
                   })() && (
                     <TypingIndicator accentColor={accentColor} isThinking={isThinking} />
+                  )}
+                  {/* Copy button — shown on hover when not streaming and there's text to copy */}
+                  {!(msg as any).streaming && getMessageText(msg) && (
+                    <div className="opacity-0 group-hover/asstmsg:opacity-100 transition-opacity">
+                      <button
+                        onClick={() => copyMessage(msg, i)}
+                        className="flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                        title={copiedIndex === i ? 'Copied' : 'Copy message'}
+                      >
+                        {copiedIndex === i ? <Check size={12} className="text-[#00FFA7]" /> : <Copy size={12} />}
+                      </button>
+                    </div>
                   )}
                 </div>
               </div>
@@ -1065,20 +1151,6 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
       {/* Input area */}
       <div className="flex-shrink-0 border-t border-[#21262d] bg-[#0d1117] px-4 py-3">
         <div className="max-w-3xl mx-auto space-y-2">
-          {/* Editing-message pill */}
-          {rewindRequest && (
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#21262d] bg-[#161b22] text-[11px] text-[#e6edf3]">
-              <Pencil size={11} className="text-[#667085] flex-shrink-0" />
-              <span className="flex-1">Editing message — previous responses will be removed</span>
-              <button
-                onClick={cancelRewind}
-                className="flex-shrink-0 text-[#667085] hover:text-[#e6edf3] transition-colors"
-                title="Cancel edit"
-              >
-                <X size={12} />
-              </button>
-            </div>
-          )}
           {/* File previews */}
           {attachedFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-1">

--- a/dashboard/terminal-server/src/server.js
+++ b/dashboard/terminal-server/src/server.js
@@ -465,6 +465,51 @@ class TerminalServer {
             chatSession.lastActivity = new Date();
             if (!chatSession.chatHistory) chatSession.chatHistory = [];
 
+            // --- Rewind handling ---
+            if (data.rewindFromUuid) {
+              const rewindUuid = data.rewindFromUuid;
+
+              // Find uuid in in-memory cache
+              let cutIdx = chatSession.chatHistory.findIndex(m => m.uuid === rewindUuid);
+
+              // Fall back to JSONL scan if cache is cold or uuid not found
+              if (cutIdx === -1 && chatSession.agentName) {
+                const fromLog = this.chatLogger.read(chatSession.agentName, wsInfo.claudeSessionId);
+                cutIdx = fromLog.findIndex(m => m.uuid === rewindUuid);
+                if (cutIdx !== -1) {
+                  // Sync cache from JSONL
+                  chatSession.chatHistory = fromLog;
+                  cutIdx = chatSession.chatHistory.findIndex(m => m.uuid === rewindUuid);
+                }
+              }
+
+              if (cutIdx === -1) {
+                // uuid not found — error out without mutating state
+                this.sendToWebSocket(wsInfo.ws, {
+                  type: 'chat_error',
+                  message: `Rewind target not found: ${rewindUuid}`,
+                });
+                chatSession.active = false;
+                break;
+              }
+
+              // 1. If a turn is streaming, stop it first
+              if (this.chatBridge.isActive(wsInfo.claudeSessionId)) {
+                await this.chatBridge.stopSession(wsInfo.claudeSessionId);
+              }
+
+              // 2. Null out sdkSessionId so the next turn starts fresh
+              chatSession.sdkSessionId = null;
+              await this.saveSessionsToDisk();
+
+              // 3. Truncate in-memory cache to everything strictly before rewindUuid
+              chatSession.chatHistory = chatSession.chatHistory.slice(0, cutIdx);
+
+              // 4. Append rewind marker to JSONL
+              this.chatLogger.appendRewindMarker(chatSession.agentName, wsInfo.claudeSessionId, rewindUuid);
+            }
+            // --- End rewind handling ---
+
             // Store user message in history
             const userMsg = {
               role: 'user',

--- a/dashboard/terminal-server/src/utils/chat-logger.js
+++ b/dashboard/terminal-server/src/utils/chat-logger.js
@@ -108,10 +108,10 @@ class ChatLogger {
       const messages = [];
       for (const entry of rawLines) {
         if (entry.type === 'rewind') {
-          // Drop everything strictly after the message with entry.at uuid
+          // Drop the message with entry.at uuid AND everything after it
           const cutIdx = messages.findIndex(m => m.uuid === entry.at);
           if (cutIdx !== -1) {
-            messages.splice(cutIdx + 1);
+            messages.splice(cutIdx);
           }
           // If uuid not found (e.g. marker for already-rewound content), no-op
         } else {

--- a/dashboard/terminal-server/src/utils/chat-logger.js
+++ b/dashboard/terminal-server/src/utils/chat-logger.js
@@ -2,7 +2,12 @@
  * ChatLogger — append-only JSONL logs for chat conversations.
  *
  * Stores chat messages in workspace/ADWs/logs/chat/{agentName}_{sessionId}.jsonl
- * Each line is a JSON object: { role, text?, blocks?, files?, ts }
+ * Each line is a JSON object: { role, text?, blocks?, files?, ts, uuid? }
+ *
+ * Special event lines:
+ *   { type: "rewind", at: <uuid>, ts }  — marks a rewind point; messages after
+ *     the referenced uuid are considered dropped. The reader applies all rewind
+ *     markers before returning results (append-only, no destructive truncation).
  *
  * This is the durable source of truth for chat history.
  * sessions.json is a fast-access cache; JSONL survives restarts and cleanups.
@@ -10,6 +15,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 class ChatLogger {
   constructor(workspaceRoot) {
@@ -31,20 +37,45 @@ class ChatLogger {
 
   /**
    * Append a message to the chat log.
+   * Assigns a uuid if the message doesn't already have one.
+   * Returns the (possibly assigned) uuid.
    */
   append(agentName, sessionId, message) {
     try {
+      if (!message.uuid) {
+        message.uuid = crypto.randomUUID();
+      }
       const logPath = this._logPath(agentName, sessionId);
       const line = JSON.stringify(message) + '\n';
       fs.appendFileSync(logPath, line, 'utf8');
+      return message.uuid;
     } catch (err) {
       console.error(`[chat-logger] Failed to append: ${err.message}`);
+      return null;
     }
   }
 
   /**
-   * Read full chat history from JSONL log.
+   * Append a rewind marker to the JSONL log.
+   * The marker records which message uuid was rewound from.
+   */
+  appendRewindMarker(agentName, sessionId, atUuid) {
+    try {
+      const marker = { type: 'rewind', at: atUuid, ts: Date.now() };
+      const logPath = this._logPath(agentName, sessionId);
+      fs.appendFileSync(logPath, JSON.stringify(marker) + '\n', 'utf8');
+    } catch (err) {
+      console.error(`[chat-logger] Failed to append rewind marker: ${err.message}`);
+    }
+  }
+
+  /**
+   * Read full chat history from JSONL log, applying rewind markers.
    * Returns array of messages, or empty array if not found.
+   *
+   * Algorithm: play forward. When a { type:"rewind", at:<uuid> } line is
+   * encountered, drop all messages strictly after the message with that uuid.
+   * Legacy messages without uuid get synthesized deterministic ids.
    */
   read(agentName, sessionId) {
     try {
@@ -54,15 +85,40 @@ class ChatLogger {
       const content = fs.readFileSync(logPath, 'utf8').trim();
       if (!content) return [];
 
-      const messages = [];
+      const rawLines = [];
       for (const line of content.split('\n')) {
         if (!line.trim()) continue;
         try {
-          messages.push(JSON.parse(line));
+          rawLines.push(JSON.parse(line));
         } catch {
           // Skip malformed lines
         }
       }
+
+      // First pass: assign synthesized uuids to legacy messages (no uuid, not a marker)
+      let idx = 0;
+      for (const entry of rawLines) {
+        if (entry.type !== 'rewind' && !entry.uuid) {
+          entry.uuid = `legacy-${sessionId}-${idx}`;
+        }
+        if (entry.type !== 'rewind') idx++;
+      }
+
+      // Second pass: play forward, applying rewind markers
+      const messages = [];
+      for (const entry of rawLines) {
+        if (entry.type === 'rewind') {
+          // Drop everything strictly after the message with entry.at uuid
+          const cutIdx = messages.findIndex(m => m.uuid === entry.at);
+          if (cutIdx !== -1) {
+            messages.splice(cutIdx + 1);
+          }
+          // If uuid not found (e.g. marker for already-rewound content), no-op
+        } else {
+          messages.push(entry);
+        }
+      }
+
       return messages;
     } catch (err) {
       console.error(`[chat-logger] Failed to read: ${err.message}`);

--- a/dashboard/terminal-server/src/utils/session-store.js
+++ b/dashboard/terminal-server/src/utils/session-store.js
@@ -126,6 +126,14 @@ class SessionStore {
             for (const session of parsed.sessions) {
                 if (!session || !session.id) continue; // Skip invalid sessions
                 
+                // Synthesize uuids for legacy chatHistory entries that lack them
+                const chatHistory = (session.chatHistory || []).map((msg, i) => {
+                    if (!msg.uuid) {
+                        return { ...msg, uuid: `legacy-${session.id}-${i}` };
+                    }
+                    return msg;
+                });
+
                 // Restore session with default values for runtime properties
                 sessions.set(session.id, {
                     ...session,
@@ -136,7 +144,7 @@ class SessionStore {
                     outputBuffer: session.outputBuffer || [],
                     maxBufferSize: 1000,
                     // Restore chat data
-                    chatHistory: session.chatHistory || [],
+                    chatHistory,
                     sdkSessionId: session.sdkSessionId || null,
                     mode: session.mode || null,
                     // Restore usage data if available


### PR DESCRIPTION
## Summary
- Adds claude.ai-style **message rewind**: each user message gets a hover-revealed pencil that turns the bubble into an inline textarea (Esc to cancel, Cmd/Ctrl+Enter to commit). Committing truncates the conversation at that point and starts a fresh Agent SDK session, so the model genuinely forgets the rewound turns.
- Adds a hover-revealed **copy button** on user and assistant messages with a brief check-icon confirmation. Assistant copy concatenates text blocks and skips tool_use cards.
- JSONL persistence stays append-only: rewinds are recorded as `{type:"rewind", at:<uuid>}` markers, applied at read time. Legacy messages without uuids get synthesized deterministic ids on load — zero disk migration.

## Implementation notes
- `chat-logger.js` — uuid synthesis, rewind-marker append, marker-aware reader
- `session-store.js` — uuid carried through the cache
- `server.js` — `chat_send` accepts `rewindFromUuid`, nulls `sdkSessionId` **before** calling `startSession` (race guard), reuses the existing `stopSession()` for mid-stream rewind aborts
- `AgentChat.tsx` — inline editor, copy buttons, optimistic message truncation on rewind

## Known limitation
Inline edit is text-only — file attachments on the original message do not carry over to the new version. Re-attach via a fresh message if needed.

## Test plan
- [ ] `cd dashboard/frontend && npx tsc --noEmit` clean
- [ ] `npm run build` clean
- [ ] Rewind a message, ask "what did I just say?" — model should not know
- [ ] Restart terminal-server after a rewind — rewound messages stay gone
- [ ] Inline edit textarea: Esc cancels, Cmd/Ctrl+Enter commits
- [ ] Copy button on user and assistant messages shows check-icon feedback
- [ ] Multi-tab staleness is a known deferred limitation (tab B shows stale state until reload)

## Summary by Sourcery

Add inline message rewind and copy capabilities to the chat UI, backed by uuid-aware, append-only JSONL logging and session rewind handling on the server.

New Features:
- Support inline editing and resending of prior user messages, truncating subsequent conversation turns from that point.
- Add hover-revealed copy buttons for user and assistant messages, with confirmation feedback and tool-output-aware text extraction.

Enhancements:
- Include stable uuids on chat messages across frontend, in-memory session cache, and persistent JSONL logs.
- Record rewind events as markers in the JSONL log and apply them at read time to reconstruct the effective chat history.
- Backfill synthesized uuids for legacy chat history entries when loading from disk to keep rewind logic consistent.