### PR TITLE
Providers overhaul: unbreak Codex OAuth, live model discovery, OpenClaude 0.3.0

### DIFF
--- a/ADWs/runner.py
+++ b/ADWs/runner.py
@@ -155,6 +155,8 @@ def _spawn_cli(cli_command: str, prompt: str, agent: str | None, provider_env: d
 _ALLOWED_ENV_VARS = frozenset({
     "CLAUDE_CODE_USE_OPENAI", "CLAUDE_CODE_USE_GEMINI", "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX", "OPENAI_BASE_URL", "OPENAI_API_KEY", "OPENAI_MODEL",
+    # Codex OAuth support (OpenClaude 0.3+ auto-reads ~/.codex/auth.json)
+    "CODEX_AUTH_JSON_PATH", "CODEX_API_KEY",
     "GEMINI_API_KEY", "GEMINI_MODEL", "AWS_REGION", "AWS_BEARER_TOKEN_BEDROCK",
     "ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION",
 })
@@ -164,6 +166,8 @@ def _get_provider_config() -> tuple[str, dict]:
     """Read active provider CLI command and env vars from config/providers.json.
 
     Only allowlisted CLI commands and env var names are returned.
+    For OpenAI-based providers, injects a sensible default OPENAI_MODEL when
+    missing — 'codexplan' for Codex OAuth, 'gpt-4.1' for plain API key mode.
     """
     config_path = WORKSPACE / "config" / "providers.json"
     if not config_path.is_file():
@@ -179,6 +183,13 @@ def _get_provider_config() -> tuple[str, dict]:
             k: v for k, v in provider.get("env_vars", {}).items()
             if v and k in _ALLOWED_ENV_VARS
         }
+        # Codex OAuth: OpenClaude expects 'codexplan' / 'codexspark' aliases
+        # to route to the Codex backend. A raw gpt-5.x string bypasses Codex.
+        if not env_vars.get("OPENAI_MODEL"):
+            if active == "codex_auth":
+                env_vars["OPENAI_MODEL"] = "codexplan"
+            elif active == "openai":
+                env_vars["OPENAI_MODEL"] = "gpt-4.1"
         return cli, env_vars
     except (json.JSONDecodeError, OSError):
         return "claude", {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN apt-get update && apt-get install -y \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 
-# Install Claude Code CLI
+# Install Claude Code CLI (default provider)
 RUN npm install -g @anthropic-ai/claude-code
+
+# Install OpenClaude CLI (required for non-Anthropic providers: OpenAI, Codex OAuth, OpenRouter, Gemini, etc.)
+RUN npm install -g @gitlawb/openclaude
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN npm install -g @anthropic-ai/claude-code
 
 # Install OpenClaude CLI (required for non-Anthropic providers: OpenAI, Codex OAuth, OpenRouter, Gemini, etc.)
-RUN npm install -g @gitlawb/openclaude
+# Pin to @latest to avoid the npm dist-tag lag; min supported is 0.3.0
+# (first version with the Codex shortcut endpoint fix, openclaude#566).
+RUN npm install -g @gitlawb/openclaude@latest
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/cli/bin/cli.mjs
+++ b/cli/bin/cli.mjs
@@ -199,10 +199,18 @@ async function main() {
   console.log(`  ${BOLD}Installing dependencies...${RESET}\n`);
 
   // Python deps
+  // Pass EVO_NEXUS_INSTALL=1 to signal setup.py that it is being run as
+  // a pip build backend — this makes it skip the interactive wizard and
+  // use setuptools.setup() for proper metadata (prevents EOFError when
+  // pip runs without a TTY).
+  const pipEnv = { ...process.env, EVO_NEXUS_INSTALL: "1" };
   if (check("uv --version")) {
     run("uv sync -q", { cwd: targetPath });
   } else {
-    run("pip3 install -q -r requirements.txt 2>/dev/null || pip3 install -q -e .", { cwd: targetPath });
+    run("pip3 install -q -r requirements.txt 2>/dev/null || pip3 install -q -e .", {
+      cwd: targetPath,
+      env: pipEnv,
+    });
   }
 
   // Frontend deps

--- a/config/providers.example.json
+++ b/config/providers.example.json
@@ -23,16 +23,30 @@
       "requires_logout": true
     },
     "openai": {
-      "name": "OpenAI",
-      "description": "GPT-4.x via API Key ou GPT-5.x via Codex OAuth",
+      "name": "OpenAI (API Key)",
+      "description": "GPT-4.x / GPT-5.x via API Key da OpenAI",
       "cli_command": "openclaude",
       "env_vars": {
         "CLAUDE_CODE_USE_OPENAI": "1",
         "OPENAI_API_KEY": "",
-        "OPENAI_MODEL": "gpt-5.4"
+        "OPENAI_MODEL": ""
       },
       "default_model": "gpt-4.1",
       "requires_logout": true
+    },
+    "codex_auth": {
+      "name": "OpenAI Codex (OAuth)",
+      "description": "GPT-5.x via ChatGPT Codex — login OAuth, sem API key",
+      "cli_command": "openclaude",
+      "env_vars": {
+        "CLAUDE_CODE_USE_OPENAI": "1",
+        "OPENAI_MODEL": "codexplan"
+      },
+      "default_model": "codexplan",
+      "auth_type": "oauth",
+      "auth_file": "~/.codex/auth.json",
+      "requires_logout": true,
+      "setup_hint": "Use o botão Login para autenticar via OAuth do ChatGPT"
     },
     "gemini": {
       "name": "Google Gemini (em breve)",

--- a/dashboard/backend/routes/providers.py
+++ b/dashboard/backend/routes/providers.py
@@ -536,6 +536,148 @@ def codex_auth_status():
     return openai_status()
 
 
+# ── Dynamic model discovery ──────────────────────────────
+#
+# These endpoints let the frontend populate the MODEL field in the Configure
+# modal with the actual list of models available to the user, instead of
+# forcing them to memorize the name.
+#
+# For the 'openai' provider we hit api.openai.com/v1/models with the user's
+# API key (POST body, never logged). For 'codex_auth' we return the static
+# list of Codex backend aliases that OpenClaude supports — these are fixed
+# by the upstream project and cannot be discovered via API.
+
+# Prefixes we consider "coding/agent relevant" — excludes embedding, tts,
+# whisper, dall-e, moderation, etc. which are not useful for Claude-Code-
+# style workflows.
+_OPENAI_MODEL_PREFIXES = (
+    "gpt-", "o1", "o3", "o4", "chatgpt-",
+)
+_OPENAI_MODEL_EXCLUDE = (
+    "embedding", "whisper", "tts", "dall-e", "audio", "moderation",
+    "realtime", "search", "image", "transcribe",
+)
+
+# Static ordering hint — lower index = higher in the dropdown
+_OPENAI_MODEL_PRIORITY = [
+    "gpt-4.1", "gpt-4o", "o4", "o3", "o1", "gpt-5", "gpt-4", "gpt-3.5", "chatgpt",
+]
+
+
+def _openai_model_rank(model_id: str) -> tuple[int, str]:
+    """Sort key — (priority bucket, lexical) so gpt-4.1 family floats to top."""
+    for i, prefix in enumerate(_OPENAI_MODEL_PRIORITY):
+        if model_id.startswith(prefix):
+            return (i, model_id)
+    return (len(_OPENAI_MODEL_PRIORITY), model_id)
+
+
+@bp.route("/api/providers/openai/models", methods=["POST"])
+@login_required
+def openai_models():
+    """Validate an OpenAI API key and return the list of usable models.
+
+    Body: {"api_key": "sk-..."}
+    Response:
+      {"valid": true, "models": [{"id": "...", "owned_by": "..."}]}
+      {"valid": false, "error": "..."}
+    """
+    import requests as http_req
+
+    data = request.get_json(silent=True) or {}
+    api_key = (data.get("api_key") or "").strip()
+
+    # Basic sanity check only: reject obviously empty/short keys before hitting
+    # the network. Delegate detailed format validation to OpenAI itself — any
+    # future format change (e.g. new key prefixes or separator chars) will be
+    # correctly rejected as 401 by the upstream /v1/models call, rather than
+    # by a stale regex in this file.
+    if not api_key or len(api_key) < 20:
+        return jsonify({"valid": False, "error": "API key inválida ou vazia"}), 400
+
+    try:
+        resp = http_req.get(
+            "https://api.openai.com/v1/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10,
+        )
+    except http_req.RequestException as e:
+        # Don't leak the key in error messages
+        return jsonify({"valid": False, "error": f"Falha de rede: {type(e).__name__}"}), 502
+
+    if resp.status_code == 401:
+        return jsonify({"valid": False, "error": "API key rejeitada pela OpenAI (401)"}), 200
+    if resp.status_code != 200:
+        return jsonify({"valid": False, "error": f"OpenAI respondeu HTTP {resp.status_code}"}), 200
+
+    try:
+        payload = resp.json()
+    except ValueError:
+        return jsonify({"valid": False, "error": "Resposta da OpenAI não é JSON"}), 502
+
+    raw_models = payload.get("data", []) or []
+
+    # Filter: only chat-completion-capable models relevant to coding agents
+    filtered = []
+    for m in raw_models:
+        mid = m.get("id", "")
+        if not mid:
+            continue
+        if not mid.startswith(_OPENAI_MODEL_PREFIXES):
+            continue
+        if any(excl in mid for excl in _OPENAI_MODEL_EXCLUDE):
+            continue
+        filtered.append({
+            "id": mid,
+            "owned_by": m.get("owned_by", ""),
+        })
+
+    filtered.sort(key=lambda m: _openai_model_rank(m["id"]))
+
+    return jsonify({"valid": True, "models": filtered, "count": len(filtered)})
+
+
+# Codex OAuth aliases — OpenClaude's Codex mode uses these literal strings
+# to route to the Codex backend. These are hardcoded upstream in OpenClaude
+# itself; there is no OpenAI endpoint to discover them dynamically.
+_CODEX_ALIASES = [
+    {
+        "id": "codexplan",
+        "description": "GPT-5.4 no backend Codex (reasoning alto, default)",
+        "description_en": "GPT-5.4 on Codex backend (high reasoning, default)",
+    },
+    {
+        "id": "codexspark",
+        "description": "GPT-5.3 Codex Spark (mais rápido, mais barato)",
+        "description_en": "GPT-5.3 Codex Spark (faster, cheaper)",
+    },
+]
+
+
+@bp.route("/api/providers/codex_auth/models", methods=["GET"])
+@login_required
+def codex_auth_models():
+    """Return the static list of Codex aliases OpenClaude supports.
+
+    Response: {"valid": bool, "models": [...], "auth_ok": bool}
+    """
+    auth_ok = False
+    if CODEX_AUTH_FILE.is_file():
+        try:
+            auth = json.loads(CODEX_AUTH_FILE.read_text(encoding="utf-8"))
+            tokens = auth.get("tokens", {})
+            auth_ok = bool(tokens.get("access_token") or auth.get("openai-codex", {}).get("access"))
+        except (json.JSONDecodeError, OSError):
+            auth_ok = False
+
+    return jsonify({
+        "valid": True,
+        "models": _CODEX_ALIASES,
+        "auth_ok": auth_ok,
+        "count": len(_CODEX_ALIASES),
+    })
+
+
 @bp.route("/api/providers/openai/logout", methods=["POST"])
 @login_required
 def openai_logout():

--- a/dashboard/backend/routes/providers.py
+++ b/dashboard/backend/routes/providers.py
@@ -43,6 +43,10 @@ ALLOWED_ENV_VARS = frozenset({
     "OPENAI_BASE_URL",
     "OPENAI_API_KEY",
     "OPENAI_MODEL",
+    # Codex OAuth support (OpenClaude 0.3+ reads ~/.codex/auth.json automatically,
+    # but these allow overriding the auth file path or providing a raw token)
+    "CODEX_AUTH_JSON_PATH",
+    "CODEX_API_KEY",
     "GEMINI_API_KEY",
     "GEMINI_MODEL",
     "AWS_REGION",
@@ -422,7 +426,10 @@ def openai_auth_complete():
     _save_codex_auth(resp.json())
 
     config = _read_config()
-    config["active_provider"] = "openai"
+    # Use dedicated codex_auth provider key when OAuth is used (falls back to
+    # openai for backward compatibility if codex_auth is not configured).
+    providers = config.get("providers", {})
+    config["active_provider"] = "codex_auth" if "codex_auth" in providers else "openai"
     _write_config(config)
 
     return jsonify({"status": "ok", "message": "Autenticado com sucesso!"})
@@ -490,7 +497,8 @@ def openai_device_poll():
     _save_codex_auth(token_resp.json())
 
     config = _read_config()
-    config["active_provider"] = "openai"
+    providers = config.get("providers", {})
+    config["active_provider"] = "codex_auth" if "codex_auth" in providers else "openai"
     _write_config(config)
 
     session.pop("openai_device_auth_id", None)
@@ -515,9 +523,17 @@ def openai_status():
             "authenticated": has_access,
             "method": "codex_oauth",
             "auth_mode": auth.get("auth_mode", "unknown"),
+            "auth_file": str(CODEX_AUTH_FILE),
         })
     except (json.JSONDecodeError, OSError):
         return jsonify({"authenticated": False, "method": "none"})
+
+
+@bp.route("/api/providers/codex_auth/status")
+@login_required
+def codex_auth_status():
+    """Alias for openai/status — reflects the dedicated codex_auth provider key."""
+    return openai_status()
 
 
 @bp.route("/api/providers/openai/logout", methods=["POST"])

--- a/dashboard/frontend/src/pages/Providers.tsx
+++ b/dashboard/frontend/src/pages/Providers.tsx
@@ -222,8 +222,8 @@ export default function Providers() {
                     <p className="text-[11px] text-[#3d4f65] mt-0.5 truncate">{prov.description}</p>
                   </div>
 
-                  {/* OpenAI auth badge */}
-                  {prov.id === 'openai' && codexAuth?.authenticated && (
+                  {/* OpenAI / Codex OAuth badge */}
+                  {(prov.id === 'openai' || prov.id === 'codex_auth') && codexAuth?.authenticated && (
                     <span className="text-[9px] px-2 py-0.5 rounded bg-[#10A37F]/10 text-[#10A37F] border border-[#10A37F]/20 shrink-0">
                       OAuth
                     </span>
@@ -231,14 +231,14 @@ export default function Providers() {
 
                   {/* Actions */}
                   <div className="flex items-center gap-2 shrink-0">
-                    {/* OpenAI login */}
-                    {prov.id === 'openai' && isInstalled && !codexAuth?.authenticated && (
+                    {/* OpenAI / Codex OAuth login */}
+                    {(prov.id === 'openai' || prov.id === 'codex_auth') && isInstalled && !codexAuth?.authenticated && (
                       <button onClick={() => { setAuthModal(true); setAuthMode('browser'); setAuthUrl(''); setCallbackUrl(''); setAuthMessage(null); setDeviceCode(null); setDevicePolling(false); startBrowserAuth() }}
                         className="text-[11px] px-3 py-1.5 rounded-md bg-[#10A37F]/10 text-[#10A37F] border border-[#10A37F]/20 hover:bg-[#10A37F]/20 transition-colors font-medium">
                         Login
                       </button>
                     )}
-                    {prov.id === 'openai' && codexAuth?.authenticated && (
+                    {(prov.id === 'openai' || prov.id === 'codex_auth') && codexAuth?.authenticated && (
                       <button onClick={handleOpenAILogout}
                         className="text-[11px] px-2 py-1 rounded-md text-[#f87171] hover:bg-[#1a0a0a] transition-colors">
                         Logout

--- a/dashboard/frontend/src/pages/Providers.tsx
+++ b/dashboard/frontend/src/pages/Providers.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { CheckCircle2, AlertCircle, RefreshCw, X } from 'lucide-react'
 import { api } from '../lib/api'
 
@@ -76,6 +76,17 @@ export default function Providers() {
   const [devicePolling, setDevicePolling] = useState(false)
   const [toggling, setToggling] = useState<string | null>(null)
 
+  // Dynamic model discovery — populated when Configure modal opens for
+  // openai/codex_auth. Shape: { [providerId]: { loading, models[], error? } }
+  type ModelList = {
+    loading: boolean;
+    models: Array<{ id: string; description?: string; owned_by?: string }>;
+    error?: string;
+    validatedKey?: string;  // remembers which API key we validated, to skip refetch
+  }
+  const [modelLists, setModelLists] = useState<Record<string, ModelList>>({})
+  const apiKeyDebounceRef = useRef<number | null>(null)
+
   const load = () => {
     setLoading(true)
     api.get('/providers').then((data: ProvidersResponse) => {
@@ -111,6 +122,78 @@ export default function Providers() {
       vars[k] = v.includes('****') ? '' : v
     }
     setEditVars(vars)
+    // Prefetch available models so the MODEL field renders as a real dropdown.
+    // - codex_auth: static list from backend, always available.
+    // - openai:     needs a valid API key first; we fetch when the user types.
+    if (prov.id === 'codex_auth') {
+      loadCodexModels()
+    } else if (prov.id === 'openai' && vars['OPENAI_API_KEY']) {
+      // If the user had a key saved (and it came through unmasked because
+      // they cleared the field), try validating it right away.
+      loadOpenAIModels(vars['OPENAI_API_KEY'])
+    }
+  }
+
+  const loadCodexModels = async () => {
+    setModelLists(prev => ({ ...prev, codex_auth: { loading: true, models: [] } }))
+    try {
+      const r: any = await api.get('/providers/codex_auth/models')
+      setModelLists(prev => ({
+        ...prev,
+        codex_auth: {
+          loading: false,
+          models: r.models || [],
+          error: r.auth_ok ? undefined : 'Faça login OAuth antes de usar — os aliases funcionam só com token Codex ativo.',
+        },
+      }))
+    } catch {
+      setModelLists(prev => ({
+        ...prev,
+        codex_auth: { loading: false, models: [], error: 'Falha ao carregar aliases Codex' },
+      }))
+    }
+  }
+
+  const loadOpenAIModels = async (apiKey: string) => {
+    const trimmed = (apiKey || '').trim()
+    if (!trimmed || trimmed.length < 20) {
+      setModelLists(prev => ({
+        ...prev,
+        openai: { loading: false, models: [], error: 'API key muito curta' },
+      }))
+      return
+    }
+    // Skip refetch if we already validated this exact key
+    const existing = modelLists.openai
+    if (existing?.validatedKey === trimmed && !existing.error) return
+
+    setModelLists(prev => ({ ...prev, openai: { loading: true, models: [] } }))
+    try {
+      const r: any = await api.post('/providers/openai/models', { api_key: trimmed })
+      if (r.valid) {
+        setModelLists(prev => ({
+          ...prev,
+          openai: { loading: false, models: r.models || [], validatedKey: trimmed },
+        }))
+      } else {
+        setModelLists(prev => ({
+          ...prev,
+          openai: { loading: false, models: [], error: r.error || 'API key inválida', validatedKey: trimmed },
+        }))
+      }
+    } catch {
+      setModelLists(prev => ({
+        ...prev,
+        openai: { loading: false, models: [], error: 'Falha na requisição' },
+      }))
+    }
+  }
+
+  // Called by the API_KEY input onChange — debounces the model fetch so we
+  // don't spam the OpenAI API on every keystroke.
+  const scheduleOpenAIModelFetch = (apiKey: string) => {
+    if (apiKeyDebounceRef.current) window.clearTimeout(apiKeyDebounceRef.current)
+    apiKeyDebounceRef.current = window.setTimeout(() => loadOpenAIModels(apiKey), 600)
   }
 
   const handleSave = async () => {
@@ -222,8 +305,8 @@ export default function Providers() {
                     <p className="text-[11px] text-[#3d4f65] mt-0.5 truncate">{prov.description}</p>
                   </div>
 
-                  {/* OpenAI / Codex OAuth badge */}
-                  {(prov.id === 'openai' || prov.id === 'codex_auth') && codexAuth?.authenticated && (
+                  {/* Codex OAuth badge — only on the dedicated codex_auth card */}
+                  {prov.id === 'codex_auth' && codexAuth?.authenticated && (
                     <span className="text-[9px] px-2 py-0.5 rounded bg-[#10A37F]/10 text-[#10A37F] border border-[#10A37F]/20 shrink-0">
                       OAuth
                     </span>
@@ -231,14 +314,14 @@ export default function Providers() {
 
                   {/* Actions */}
                   <div className="flex items-center gap-2 shrink-0">
-                    {/* OpenAI / Codex OAuth login */}
-                    {(prov.id === 'openai' || prov.id === 'codex_auth') && isInstalled && !codexAuth?.authenticated && (
+                    {/* Codex OAuth login / logout — only on codex_auth card */}
+                    {prov.id === 'codex_auth' && isInstalled && !codexAuth?.authenticated && (
                       <button onClick={() => { setAuthModal(true); setAuthMode('browser'); setAuthUrl(''); setCallbackUrl(''); setAuthMessage(null); setDeviceCode(null); setDevicePolling(false); startBrowserAuth() }}
                         className="text-[11px] px-3 py-1.5 rounded-md bg-[#10A37F]/10 text-[#10A37F] border border-[#10A37F]/20 hover:bg-[#10A37F]/20 transition-colors font-medium">
                         Login
                       </button>
                     )}
-                    {(prov.id === 'openai' || prov.id === 'codex_auth') && codexAuth?.authenticated && (
+                    {prov.id === 'codex_auth' && codexAuth?.authenticated && (
                       <button onClick={handleOpenAILogout}
                         className="text-[11px] px-2 py-1 rounded-md text-[#f87171] hover:bg-[#1a0a0a] transition-colors">
                         Logout
@@ -310,18 +393,87 @@ export default function Providers() {
                 {editableVars.length === 0 ? (
                   <p className="text-sm text-[#5a6b7f]">No configuration needed. Uses native Claude Code authentication.</p>
                 ) : (
-                  editableVars.map(([key]) => (
-                    <div key={key}>
-                      <label className={lbl}>
-                        {ENV_VAR_LABELS[key] || key}
-                        <span className="ml-1 text-[#3d4f65] font-normal normal-case tracking-normal">({key})</span>
-                      </label>
-                      <input type={isSecret(key) ? 'password' : 'text'} value={editVars[key] || ''}
-                        onChange={(e) => setEditVars(prev => ({ ...prev, [key]: e.target.value }))}
-                        placeholder={key.includes('KEY') ? 'sk-...' : key.includes('MODEL') ? (prov.default_model || '') : key.includes('URL') ? (prov.default_base_url || 'https://...') : ''}
-                        className={inp} autoComplete="off" />
-                    </div>
-                  ))
+                  editableVars.map(([key]) => {
+                    const isModelField = key.includes('MODEL')
+                    const isApiKeyField = key === 'OPENAI_API_KEY'
+                    const currentList = modelLists[prov.id]
+                    const hasDiscoveredModels = isModelField
+                      && (prov.id === 'openai' || prov.id === 'codex_auth')
+                      && currentList
+                      && currentList.models.length > 0
+
+                    return (
+                      <div key={key}>
+                        <label className={lbl}>
+                          {ENV_VAR_LABELS[key] || key}
+                          <span className="ml-1 text-[#3d4f65] font-normal normal-case tracking-normal">({key})</span>
+                          {isModelField && currentList?.loading && (
+                            <span className="ml-2 text-[#5a6b7f]"><RefreshCw size={10} className="inline animate-spin" /> carregando…</span>
+                          )}
+                        </label>
+
+                        {hasDiscoveredModels ? (
+                          <>
+                            {/* datalist-backed combobox: shows dropdown but accepts free text */}
+                            <input
+                              type="text"
+                              list={`${prov.id}-models`}
+                              value={editVars[key] || ''}
+                              onChange={(e) => setEditVars(prev => ({ ...prev, [key]: e.target.value }))}
+                              placeholder={prov.default_model || 'Selecione ou digite um modelo'}
+                              className={inp}
+                              autoComplete="off"
+                            />
+                            <datalist id={`${prov.id}-models`}>
+                              {currentList!.models.map(m => (
+                                <option key={m.id} value={m.id}>{m.description || m.owned_by || ''}</option>
+                              ))}
+                            </datalist>
+                            <p className="text-[10px] text-[#3d4f65] mt-1">
+                              {currentList!.models.length} modelos disponíveis. Clique no campo para ver a lista.
+                            </p>
+                          </>
+                        ) : (
+                          <input
+                            type={isSecret(key) ? 'password' : 'text'}
+                            value={editVars[key] || ''}
+                            onChange={(e) => {
+                              const v = e.target.value
+                              setEditVars(prev => ({ ...prev, [key]: v }))
+                              // When the OpenAI API key changes, fetch models (debounced)
+                              if (isApiKeyField && prov.id === 'openai') {
+                                scheduleOpenAIModelFetch(v)
+                              }
+                            }}
+                            placeholder={key.includes('KEY') ? 'sk-...' : key.includes('MODEL') ? (prov.default_model || '') : key.includes('URL') ? (prov.default_base_url || 'https://...') : ''}
+                            className={inp}
+                            autoComplete="off"
+                          />
+                        )}
+
+                        {/* Inline validation feedback for the API key field */}
+                        {isApiKeyField && prov.id === 'openai' && currentList && !currentList.loading && (
+                          currentList.error ? (
+                            <p className="text-[10px] text-[#f87171] mt-1">
+                              <AlertCircle size={10} className="inline mr-1" />{currentList.error}
+                            </p>
+                          ) : currentList.models.length > 0 ? (
+                            <p className="text-[10px] text-[#00FFA7] mt-1">
+                              <CheckCircle2 size={10} className="inline mr-1" />
+                              API key válida — {currentList.models.length} modelos carregados
+                            </p>
+                          ) : null
+                        )}
+
+                        {/* Codex auth hint */}
+                        {isModelField && prov.id === 'codex_auth' && currentList?.error && (
+                          <p className="text-[10px] text-[#FBBF24] mt-1">
+                            <AlertCircle size={10} className="inline mr-1" />{currentList.error}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })
                 )}
 
                 {prov.default_model && (

--- a/dashboard/frontend/src/pages/Providers.tsx
+++ b/dashboard/frontend/src/pages/Providers.tsx
@@ -54,6 +54,124 @@ function Toggle({ on, onChange, disabled }: { on: boolean; onChange: (v: boolean
   )
 }
 
+// Custom combobox — styled dropdown that lets users pick a discovered model
+// but also accept free-text input for edge cases (new models, custom routes).
+// Replaces <datalist>, whose browser-native rendering was unreliable
+// (appeared as an OS-level sidebar with "owned_by" noise, no consistent
+// styling, and click-to-select that looked like plain text insertion
+// rather than a dropdown).
+interface ComboboxOption { id: string; description?: string; owned_by?: string }
+interface ModelComboboxProps {
+  value: string
+  onChange: (v: string) => void
+  options: ComboboxOption[]
+  placeholder?: string
+  inputClassName: string
+}
+
+function ModelCombobox({ value, onChange, options, placeholder, inputClassName }: ModelComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState(value)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  // Keep internal query in sync if parent resets the value externally
+  useEffect(() => { setQuery(value) }, [value])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const q = query.toLowerCase().trim()
+  const filtered = q
+    ? options.filter(o => o.id.toLowerCase().includes(q))
+    : options
+
+  const pick = (id: string) => {
+    setQuery(id)
+    onChange(id)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            const v = e.target.value
+            setQuery(v)
+            onChange(v)
+            if (!open) setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setOpen(false)
+            if (e.key === 'ArrowDown' && !open) setOpen(true)
+          }}
+          placeholder={placeholder}
+          className={`${inputClassName} pr-9`}
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={open}
+        />
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          tabIndex={-1}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded text-[#5a6b7f] hover:text-[#e2e8f0] transition-colors"
+          aria-label="Toggle model list"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className={`transition-transform ${open ? 'rotate-180' : ''}`}>
+            <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+      {open && filtered.length > 0 && (
+        <div className="absolute z-[60] top-full left-0 right-0 mt-1 max-h-64 overflow-y-auto rounded-lg bg-[#0b1018] border border-[#1e2a3a] shadow-[0_8px_24px_rgba(0,0,0,0.5)]">
+          {filtered.map(m => {
+            const isActive = m.id === value
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => pick(m.id)}
+                className={`w-full text-left px-3 py-2 transition-colors border-b border-[#152030] last:border-b-0 ${
+                  isActive
+                    ? 'bg-[#00FFA7]/10 text-[#00FFA7]'
+                    : 'text-[#e2e8f0] hover:bg-[#152030]'
+                }`}
+              >
+                <div className="font-mono text-xs">{m.id}</div>
+                {m.description && (
+                  <div className={`text-[10px] mt-0.5 ${isActive ? 'text-[#00FFA7]/70' : 'text-[#5a6b7f]'}`}>
+                    {m.description}
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+      {open && filtered.length === 0 && (
+        <div className="absolute z-[60] top-full left-0 right-0 mt-1 rounded-lg bg-[#0b1018] border border-[#1e2a3a] shadow-[0_8px_24px_rgba(0,0,0,0.5)]">
+          <div className="px-3 py-2.5 text-[11px] text-[#5a6b7f]">
+            Nenhum modelo corresponde — {q ? 'ajuste a busca' : 'use o texto livre'}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function Providers() {
   const [providers, setProviders] = useState<Provider[]>([])
   const [activeProvider, setActiveProvider] = useState('anthropic')
@@ -414,23 +532,15 @@ export default function Providers() {
 
                         {hasDiscoveredModels ? (
                           <>
-                            {/* datalist-backed combobox: shows dropdown but accepts free text */}
-                            <input
-                              type="text"
-                              list={`${prov.id}-models`}
+                            <ModelCombobox
                               value={editVars[key] || ''}
-                              onChange={(e) => setEditVars(prev => ({ ...prev, [key]: e.target.value }))}
+                              onChange={(v) => setEditVars(prev => ({ ...prev, [key]: v }))}
+                              options={currentList!.models}
                               placeholder={prov.default_model || 'Selecione ou digite um modelo'}
-                              className={inp}
-                              autoComplete="off"
+                              inputClassName={inp}
                             />
-                            <datalist id={`${prov.id}-models`}>
-                              {currentList!.models.map(m => (
-                                <option key={m.id} value={m.id}>{m.description || m.owned_by || ''}</option>
-                              ))}
-                            </datalist>
                             <p className="text-[10px] text-[#3d4f65] mt-1">
-                              {currentList!.models.length} modelos disponíveis. Clique no campo para ver a lista.
+                              {currentList!.models.length} modelos disponíveis. Clique no campo ou na seta para abrir a lista.
                             </p>
                           </>
                         ) : (

--- a/dashboard/terminal-server/src/claude-bridge.js
+++ b/dashboard/terminal-server/src/claude-bridge.js
@@ -49,13 +49,29 @@ class ClaudeBridge {
         )
       );
 
-      // If Codex OAuth auth.json exists, remove OPENAI_API_KEY to let
-      // OpenClaude use the OAuth token instead of a potentially stale key
-      if (active === 'openai' || active === 'codex_auth') {
-        const codexAuthPath = path.join(process.env.HOME || '/', '.codex', 'auth.json');
-        if (fs.existsSync(codexAuthPath)) {
+      // Provider isolation — the active_provider in providers.json is the
+      // user's explicit choice between API-key mode ('openai') and OAuth
+      // mode ('codex_auth'). Respect it literally:
+      //
+      //   active === 'codex_auth' → OAuth mode: remove any stale
+      //       OPENAI_API_KEY from the provider env so OpenClaude falls
+      //       back to ~/.codex/auth.json (the OAuth token source).
+      //
+      //   active === 'openai'    → API-key mode: keep OPENAI_API_KEY.
+      //       Even if ~/.codex/auth.json happens to exist on disk (from
+      //       a past OAuth login), the user has chosen API-key mode now.
+      //       Previously this branch also deleted the key, which caused
+      //       the two cards to bleed into each other on toggle.
+      //
+      //   anything else          → untouched.
+      if (active === 'codex_auth') {
+        if ('OPENAI_API_KEY' in envVars) {
           delete envVars['OPENAI_API_KEY'];
-          console.log('[provider] Codex auth.json found — using OAuth token, removing OPENAI_API_KEY');
+          console.log('[provider] codex_auth active — stripping OPENAI_API_KEY, OpenClaude will use ~/.codex/auth.json');
+        }
+        const codexAuthPath = path.join(process.env.HOME || '/', '.codex', 'auth.json');
+        if (!fs.existsSync(codexAuthPath)) {
+          console.warn('[provider] codex_auth active but ~/.codex/auth.json is missing — run OAuth login in the Providers page');
         }
       }
 

--- a/dashboard/terminal-server/src/claude-bridge.js
+++ b/dashboard/terminal-server/src/claude-bridge.js
@@ -18,6 +18,9 @@ class ClaudeBridge {
       'CLAUDE_CODE_USE_OPENAI', 'CLAUDE_CODE_USE_GEMINI',
       'CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX',
       'OPENAI_BASE_URL', 'OPENAI_API_KEY', 'OPENAI_MODEL',
+      // Codex OAuth support (OpenClaude 0.3+ reads ~/.codex/auth.json
+      // automatically, but these allow overriding the path or token)
+      'CODEX_AUTH_JSON_PATH', 'CODEX_API_KEY',
       'GEMINI_API_KEY', 'GEMINI_MODEL',
       'AWS_REGION', 'AWS_BEARER_TOKEN_BEDROCK',
       'ANTHROPIC_VERTEX_PROJECT_ID', 'CLOUD_ML_REGION',
@@ -211,12 +214,23 @@ class ClaudeBridge {
         if (process.env[key]) cleanEnv[key] = process.env[key];
       }
 
-      // Ensure OPENAI_MODEL is set when using OpenAI provider.
-      // Without it, OpenClaude can't resolve which model to use and
-      // falls back to API key auth instead of Codex OAuth auth.json.
-      if ((active === 'openai' || active === 'codex_auth') && !providerEnv['OPENAI_MODEL']) {
-        providerEnv['OPENAI_MODEL'] = 'gpt-5.4';
-        console.log('[provider] OPENAI_MODEL not set — defaulting to gpt-5.4');
+      // Ensure OPENAI_MODEL is set when using an OpenAI-based provider.
+      // OpenClaude's Codex mode requires 'codexplan' or 'codexspark' aliases
+      // to route to the Codex backend — a raw 'gpt-5.x' falls back to the
+      // regular chat completions API, which bypasses Codex OAuth entirely.
+      //
+      //   codexplan  → GPT-5.4 on Codex backend (high reasoning)
+      //   codexspark → GPT-5.3 Codex Spark (faster)
+      //
+      // For the plain 'openai' provider (API key mode), default to gpt-4.1.
+      if (!providerEnv['OPENAI_MODEL']) {
+        if (active === 'codex_auth') {
+          providerEnv['OPENAI_MODEL'] = 'codexplan';
+          console.log('[provider] OPENAI_MODEL not set — defaulting to codexplan (Codex OAuth)');
+        } else if (active === 'openai') {
+          providerEnv['OPENAI_MODEL'] = 'gpt-4.1';
+          console.log('[provider] OPENAI_MODEL not set — defaulting to gpt-4.1');
+        }
       }
 
       console.log(`[spawn] Args: ${JSON.stringify(args)}`);

--- a/docs/providers/codex-oauth.md
+++ b/docs/providers/codex-oauth.md
@@ -1,0 +1,213 @@
+# OpenAI Codex (OAuth) — Provider Guide
+
+> 🇧🇷 Português abaixo — [pular para versão PT-BR](#pt-br-guia-do-provider-openai-codex-oauth)
+
+---
+
+## 🇬🇧 English
+
+### What is the Codex OAuth provider?
+
+The `codex_auth` provider lets EvoNexus run agents on **GPT-5.x via the ChatGPT Codex backend** — using your regular ChatGPT login, no API key required. It routes through [OpenClaude](https://github.com/Gitlawb/openclaude) (v0.3.0+), which reads `~/.codex/auth.json` and exchanges the OAuth token automatically.
+
+This is distinct from the plain `openai` provider, which uses an `OPENAI_API_KEY` and hits the standard chat completions endpoint.
+
+### Prerequisites
+
+| Tool | Install |
+|------|---------|
+| OpenClaude 0.3.0+ | `npm install -g @gitlawb/openclaude` |
+| An active ChatGPT account | [chatgpt.com](https://chatgpt.com) |
+
+The dashboard's Providers page also shows the current OpenClaude version and a Test button to confirm it's reachable.
+
+### Setup
+
+1. Open the dashboard at `http://localhost:8080` and go to **Providers**.
+2. Find the **OpenAI Codex (OAuth)** card.
+3. Click **Login** — a modal opens with two options:
+   - **Browser OAuth** — opens `auth.openai.com` in your browser; after signing in, paste the callback URL back into the modal.
+   - **Device Auth** — shows a code you type at `auth.openai.com/codex/device`. Some organizations disable this flow — if so, use Browser OAuth.
+4. On success, the card shows an **OAuth** badge and the provider becomes active automatically.
+
+Behind the scenes, the dashboard backend writes `~/.codex/auth.json` in the format OpenClaude expects:
+
+```json
+{
+  "auth_mode": "Chatgpt",
+  "tokens": {
+    "access_token": "…",
+    "refresh_token": "…",
+    "id_token": "…",
+    "account_id": "…"
+  },
+  "last_refresh": "2026-04-17T…Z"
+}
+```
+
+### How sessions are spawned
+
+When you start a terminal session or run an ADW routine with `codex_auth` active, both `dashboard/terminal-server/src/claude-bridge.js` and `ADWs/runner.py`:
+
+1. Read `config/providers.json` and pick the `codex_auth` entry.
+2. Inject **only** `CLAUDE_CODE_USE_OPENAI=1` and `OPENAI_MODEL=codexplan` (the default) into the child process.
+3. Strip `OPENAI_API_KEY` from the environment — even if it's set globally — so OpenClaude does not fall back to API-key auth.
+4. Inherit `CODEX_HOME` from the parent shell if set, letting advanced users point `~/.codex/` elsewhere.
+
+OpenClaude sees `~/.codex/auth.json` and authenticates automatically. No token ever lands in `providers.json` or `.env`.
+
+### Model aliases
+
+OpenClaude's Codex mode uses **aliases**, not raw model names:
+
+| Alias | Model | Use case |
+|-------|-------|----------|
+| `codexplan` | GPT-5.4 on Codex backend (high reasoning) | Default — complex agent work, long context |
+| `codexspark` | GPT-5.3 Codex Spark (faster, cheaper) | Loops, quick iteration |
+
+> ⚠️ **Setting `OPENAI_MODEL=gpt-5.4` explicitly breaks Codex OAuth** — it routes to the plain chat completions endpoint, which requires an API key, and falls back to failure. Always use an alias.
+
+### Advanced overrides
+
+These environment variables are on the allowlist (see `dashboard/backend/routes/providers.py::ALLOWED_ENV_VARS`). You can set them in the provider's `env_vars` via the Configure button:
+
+| Variable | Purpose |
+|----------|---------|
+| `CODEX_AUTH_JSON_PATH` | Override the auth file location (default: `~/.codex/auth.json`) |
+| `CODEX_API_KEY` | Raw token override — skips the auth.json read entirely |
+
+### Troubleshooting
+
+**`openclaude` not found when running as `evonexus` service user**
+Setup v0.23.3+ installs OpenClaude for the service user under `~/.local`. If you upgraded from an older version, run:
+
+```bash
+su - evonexus -c 'npm install -g @gitlawb/openclaude --prefix ~/.local'
+```
+
+**Session dies immediately, logs show "authentication failed"**
+Your token probably expired. OpenClaude refreshes automatically, but if that fails:
+
+1. Dashboard → Providers → OpenAI Codex → **Logout**, then **Login** again.
+2. Or manually: `rm ~/.codex/auth.json` and re-auth via dashboard.
+
+**"Model not found" errors**
+You likely have `OPENAI_MODEL=gpt-5.4` (or similar raw name) set globally. Remove it from `.env` and let the provider default (`codexplan`) kick in.
+
+**Codex Auth works in dashboard but not in ADW routines**
+Check that `config/providers.json` lists `codex_auth` as `active_provider` and that `ADWs/runner.py` is the current version — it reads `providers.json` fresh on every call.
+
+### How this differs from `openai` (API key)
+
+| | `openai` | `codex_auth` |
+|--|--|--|
+| Auth method | `OPENAI_API_KEY` env var | OAuth token in `~/.codex/auth.json` |
+| Endpoint | `api.openai.com/v1/chat/completions` | Codex backend via `/responses` |
+| Default model | `gpt-4.1` | `codexplan` |
+| Cost | Pay per token | Covered by ChatGPT subscription |
+| Token rotation | Manual | Automatic (OpenClaude handles refresh) |
+
+---
+
+## 🇧🇷 Guia do provider OpenAI Codex (OAuth) {#pt-br-guia-do-provider-openai-codex-oauth}
+
+### O que é o provider Codex OAuth?
+
+O provider `codex_auth` faz o EvoNexus rodar agentes no **GPT-5.x via backend Codex do ChatGPT** — usando seu login normal do ChatGPT, sem API key. A chamada passa pelo [OpenClaude](https://github.com/Gitlawb/openclaude) (v0.3.0+), que lê o `~/.codex/auth.json` e troca o token OAuth automaticamente.
+
+É diferente do provider `openai` normal, que usa `OPENAI_API_KEY` e bate no endpoint padrão de chat completions.
+
+### Pré-requisitos
+
+| Ferramenta | Instalação |
+|------------|------------|
+| OpenClaude 0.3.0+ | `npm install -g @gitlawb/openclaude` |
+| Conta ativa no ChatGPT | [chatgpt.com](https://chatgpt.com) |
+
+A página Providers do dashboard mostra a versão atual do OpenClaude e tem um botão Test pra confirmar que está acessível.
+
+### Setup
+
+1. Abra o dashboard em `http://localhost:8080` e vá em **Providers**.
+2. Encontre o card **OpenAI Codex (OAuth)**.
+3. Clique em **Login** — um modal abre com duas opções:
+   - **Browser OAuth** — abre `auth.openai.com` no navegador; depois de logar, cole a URL de callback de volta no modal.
+   - **Device Auth** — mostra um código pra você digitar em `auth.openai.com/codex/device`. Algumas organizações desabilitam esse fluxo — se for o caso, use o Browser OAuth.
+4. Dando certo, o card mostra a badge **OAuth** e o provider vira ativo automaticamente.
+
+Por baixo, o backend do dashboard grava `~/.codex/auth.json` no formato que o OpenClaude espera:
+
+```json
+{
+  "auth_mode": "Chatgpt",
+  "tokens": {
+    "access_token": "…",
+    "refresh_token": "…",
+    "id_token": "…",
+    "account_id": "…"
+  },
+  "last_refresh": "2026-04-17T…Z"
+}
+```
+
+### Como as sessões são abertas
+
+Quando você inicia uma sessão de terminal ou roda uma rotina ADW com `codex_auth` ativo, tanto `dashboard/terminal-server/src/claude-bridge.js` quanto `ADWs/runner.py`:
+
+1. Leem o `config/providers.json` e pegam a entrada `codex_auth`.
+2. Injetam **só** `CLAUDE_CODE_USE_OPENAI=1` e `OPENAI_MODEL=codexplan` (o default) no processo filho.
+3. Removem `OPENAI_API_KEY` do environment — mesmo que esteja setado globalmente — pra que o OpenClaude não caia pro fluxo de API key.
+4. Herdam `CODEX_HOME` do shell pai se setado, deixando usuários avançados apontarem `~/.codex/` pra outro lugar.
+
+O OpenClaude enxerga o `~/.codex/auth.json` e autentica sozinho. Nenhum token encosta no `providers.json` ou no `.env`.
+
+### Aliases de modelo
+
+O modo Codex do OpenClaude usa **aliases**, não nomes crus de modelo:
+
+| Alias | Modelo | Quando usar |
+|-------|--------|-------------|
+| `codexplan` | GPT-5.4 no backend Codex (reasoning alto) | Default — trabalho complexo de agente, contexto longo |
+| `codexspark` | GPT-5.3 Codex Spark (mais rápido, mais barato) | Loops, iteração rápida |
+
+> ⚠️ **Setar `OPENAI_MODEL=gpt-5.4` explicitamente quebra o Codex OAuth** — o OpenClaude manda a chamada pro endpoint de chat completions puro, que exige API key, e dá erro. Sempre use um alias.
+
+### Overrides avançados
+
+Essas variáveis de ambiente estão no allowlist (ver `dashboard/backend/routes/providers.py::ALLOWED_ENV_VARS`). Dá pra setar via botão Configure do provider:
+
+| Variável | Função |
+|----------|--------|
+| `CODEX_AUTH_JSON_PATH` | Override do arquivo de auth (default: `~/.codex/auth.json`) |
+| `CODEX_API_KEY` | Token cru — pula a leitura do auth.json |
+
+### Troubleshooting
+
+**`openclaude` não encontrado ao rodar como service user `evonexus`**
+Setup v0.23.3+ instala o OpenClaude pro service user em `~/.local`. Se você fez upgrade de uma versão antiga, rode:
+
+```bash
+su - evonexus -c 'npm install -g @gitlawb/openclaude --prefix ~/.local'
+```
+
+**Sessão morre na hora, logs mostram "authentication failed"**
+Provavelmente seu token expirou. O OpenClaude faz refresh automático, mas se falhar:
+
+1. Dashboard → Providers → OpenAI Codex → **Logout**, depois **Login** de novo.
+2. Ou manualmente: `rm ~/.codex/auth.json` e re-autentique via dashboard.
+
+**Erros de "Model not found"**
+Você provavelmente tem `OPENAI_MODEL=gpt-5.4` (ou outro nome cru) setado globalmente. Tira do `.env` e deixa o default do provider (`codexplan`) entrar.
+
+**Codex Auth funciona no dashboard mas não nas rotinas ADW**
+Confirme que `config/providers.json` lista `codex_auth` como `active_provider` e que `ADWs/runner.py` está na versão atual — ele lê o `providers.json` fresco em cada chamada.
+
+### Como isso difere do `openai` (API key)
+
+| | `openai` | `codex_auth` |
+|--|--|--|
+| Método de auth | env var `OPENAI_API_KEY` | Token OAuth em `~/.codex/auth.json` |
+| Endpoint | `api.openai.com/v1/chat/completions` | Backend Codex via `/responses` |
+| Modelo default | `gpt-4.1` | `codexplan` |
+| Custo | Por token | Incluso na assinatura ChatGPT |
+| Rotação de token | Manual | Automática (OpenClaude cuida do refresh) |

--- a/setup.py
+++ b/setup.py
@@ -78,39 +78,71 @@ def banner():
 """)
 
 
-def _check_tool(name, cmd, install_cmd=None, install_label=None):
+def _parse_semver(s: str) -> tuple[int, int, int] | None:
+    """Extract (major, minor, patch) from a version string. None on failure."""
+    import re
+    m = re.search(r'(\d+)\.(\d+)\.(\d+)', s or "")
+    if not m:
+        return None
+    try:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    except (ValueError, TypeError):
+        return None
+
+
+def _check_tool(name, cmd, install_cmd=None, install_label=None, min_version=None):
     """Check if a tool is installed. If not, offer to install it.
+
+    If min_version=(major, minor, patch) is given and the installed tool is
+    older, treat it as missing and trigger the install path — this forces an
+    upgrade when the pinned install_cmd specifies a newer version.
 
     In non-interactive contexts (pip build backend, npx pipe, CI) we skip
     the input() prompt — this is what fixes EOFError from upstream PR #11.
     When auto-confirm is appropriate (service user bootstrap), callers can
     pass EVO_NEXUS_AUTO_INSTALL=1 to proceed without prompting.
     """
+    needs_upgrade = False
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
         if result.returncode == 0:
             version = result.stdout.strip() or result.stderr.strip()
-            print(f"  {GREEN}✓{RESET} {name}: {DIM}{version}{RESET}")
-            return True
+            if min_version is not None:
+                parsed = _parse_semver(version)
+                if parsed is not None and parsed < min_version:
+                    required = ".".join(str(x) for x in min_version)
+                    print(f"  {YELLOW}!{RESET} {name}: {DIM}{version}{RESET} (upgrading to {required}+)")
+                    needs_upgrade = True
+                else:
+                    print(f"  {GREEN}✓{RESET} {name}: {DIM}{version}{RESET}")
+                    return True
+            else:
+                print(f"  {GREEN}✓{RESET} {name}: {DIM}{version}{RESET}")
+                return True
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
     if install_cmd:
-        print(f"  {YELLOW}!{RESET} {name} not found")
+        if not needs_upgrade:
+            print(f"  {YELLOW}!{RESET} {name} not found")
         # Non-interactive: skip the prompt entirely. Either auto-install
         # (when EVO_NEXUS_AUTO_INSTALL=1) or report missing.
         auto_install = os.environ.get("EVO_NEXUS_AUTO_INSTALL") == "1"
-        if not _IS_TTY and not auto_install:
+        # For upgrades we always proceed silently — the user already has
+        # the tool and we just need a newer version.
+        if needs_upgrade:
+            choice = "y"
+        elif not _IS_TTY and not auto_install:
             print(f"    {DIM}Skipping auto-install in non-interactive mode.{RESET}")
             print(f"    {DIM}Run manually: {install_cmd}{RESET}")
             return False
-
-        if auto_install:
+        elif auto_install:
             choice = "y"
         else:
             choice = input(f"    Install {name}? (Y/n): ").strip().lower()
         if choice in ("", "y", "yes", "s", "sim"):
-            print(f"  {DIM}Installing {name}...{RESET}", end="", flush=True)
+            verb_present, verb_base = ("Upgrading", "upgrade") if needs_upgrade else ("Installing", "install")
+            print(f"  {DIM}{verb_present} {name}...{RESET}", end="", flush=True)
             ret = os.system(f"{install_cmd} > /dev/null 2>&1")
             # Re-check after install
             try:
@@ -121,7 +153,7 @@ def _check_tool(name, cmd, install_cmd=None, install_label=None):
                     return True
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 pass
-            print(f"\r  {RED}✗{RESET} Failed to install {name}                    ")
+            print(f"\r  {RED}✗{RESET} Failed to {verb_base} {name}                    ")
         else:
             print(f"  {RED}✗{RESET} {name} is required for EvoNexus")
     else:
@@ -215,8 +247,13 @@ def check_prerequisites():
         missing.append("claude")
 
     # OpenClaude (required for non-Anthropic providers)
+    # min_version=(0, 3, 0) forces an upgrade on systems that already have
+    # an older OpenClaude installed — v0.3.0 is the first release with the
+    # "route OpenAI Codex shortcuts to correct endpoint" fix (#566) which
+    # the codex_auth provider flow relies on.
     if not _check_tool("OpenClaude", ["openclaude", "--version"],
-                        install_cmd="npm install -g @gitlawb/openclaude"):
+                        install_cmd="npm install -g @gitlawb/openclaude@latest",
+                        min_version=(0, 3, 0)):
         missing.append("openclaude")
 
     print()
@@ -992,10 +1029,19 @@ def main():
         # OpenClaude is required for non-Anthropic providers (OpenAI, Codex OAuth,
         # OpenRouter, Gemini, etc.). Without it, switching provider in the
         # dashboard does not work for the service user.
-        ret = os.system(f"su - {service_user} -c 'export PATH=$HOME/.local/bin:$PATH && command -v openclaude' >/dev/null 2>&1")
-        if ret != 0:
-            print(f"  {DIM}Installing OpenClaude for {service_user}...{RESET}")
-            os.system(f"su - {service_user} -c 'npm install -g @gitlawb/openclaude --prefix ~/.local' >/dev/null 2>&1")
+        # Check if installed AND on a new-enough version (0.3.0+); otherwise (re)install.
+        oc_version = subprocess.run(
+            ["su", "-", service_user, "-c", "export PATH=$HOME/.local/bin:$PATH && openclaude --version 2>/dev/null || true"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+        oc_parsed = _parse_semver(oc_version)
+        oc_ok = oc_parsed is not None and oc_parsed >= (0, 3, 0)
+        if not oc_ok:
+            if oc_parsed is not None:
+                print(f"  {DIM}Upgrading OpenClaude for {service_user} (found {oc_version}, need 0.3.0+)...{RESET}")
+            else:
+                print(f"  {DIM}Installing OpenClaude for {service_user}...{RESET}")
+            os.system(f"su - {service_user} -c 'npm install -g @gitlawb/openclaude@latest --prefix ~/.local' >/dev/null 2>&1")
             print(f"  {GREEN}✓{RESET} OpenClaude installed")
 
         # Sync deps as service user

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@
 EvoNexus — Setup Wizard
 Generates workspace configuration, CLAUDE.md, .env, and folder structure.
 Usage: python setup.py  (or: make setup)
+
+This file also doubles as a setuptools build backend when invoked by pip
+(e.g. via `pip install -e .` or `npx @evoapi/evo-nexus`). In that case the
+interactive wizard is skipped and only package metadata is produced — see
+`_IS_BUILD_BACKEND` below.
 """
 
 import os
@@ -13,17 +18,47 @@ from pathlib import Path
 
 WORKSPACE = Path(__file__).parent
 
-# Detect if running in interactive terminal (vs pip/automated context)
-IS_TTY = sys.stdin.isatty()
+# ── Non-interactive / build-backend detection ──────────────────────────
+#
+# We use TWO signals (narrow and explicit) to avoid the false-positive
+# problem Sourcery flagged on upstream PR #11:
+#
+#   1. _IS_TTY    — true when stdin is an interactive terminal.
+#                   Fixes the EOFError from `input()` under pip/npx.
+#
+#   2. _IS_BUILD_BACKEND — true ONLY when setuptools/pip is the caller.
+#                   Detected via the explicit env var EVO_NEXUS_INSTALL=1
+#                   (set by cli/bin/cli.mjs) or narrow argv markers that
+#                   setuptools always injects (egg_info / dist_info /
+#                   bdist_wheel / --editable). We deliberately do NOT use
+#                   generic args like --version because a direct call
+#                   `python setup.py --version` should remain interactive-ish.
+#
+_IS_TTY = sys.stdin.isatty() if sys.stdin else False
 
-# Detect if running as pip/setuptools build backend (not interactive setup)
-# pip sets these env vars when invoking setup.py as a build backend
+_BUILD_ARGV_MARKERS = {"egg_info", "dist_info", "bdist_wheel", "sdist", "--editable"}
 _IS_BUILD_BACKEND = (
-    "SETUPTOOLS_USE_DISTUTILS" in os.environ
-    or "PIP_REQUIREMENTS_GEN" in os.environ
-    or os.environ.get("EVO_NEXUS_INSTALL") == "1"
-    or any(arg in sys.argv for arg in ["--with-specifier-add", "egg_info", "--version", "dist_info", "--editable"])
+    os.environ.get("EVO_NEXUS_INSTALL") == "1"
+    or any(a in _BUILD_ARGV_MARKERS for a in sys.argv[1:])
 )
+
+
+def _read_version_from_pyproject() -> str:
+    """Single source of truth for the package version.
+
+    Reads [project].version from pyproject.toml. Avoids the drift risk
+    Sourcery flagged on PR #11 (hardcoded "0.23.2" string).
+    """
+    try:
+        import re
+        pyproject = (WORKSPACE / "pyproject.toml").read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+        if match:
+            return match.group(1)
+    except (OSError, ImportError):
+        pass
+    return "0.0.0"  # fallback; never expected in practice
+
 
 # ANSI colors
 GREEN = "\033[92m"
@@ -44,7 +79,13 @@ def banner():
 
 
 def _check_tool(name, cmd, install_cmd=None, install_label=None):
-    """Check if a tool is installed. If not, offer to install it."""
+    """Check if a tool is installed. If not, offer to install it.
+
+    In non-interactive contexts (pip build backend, npx pipe, CI) we skip
+    the input() prompt — this is what fixes EOFError from upstream PR #11.
+    When auto-confirm is appropriate (service user bootstrap), callers can
+    pass EVO_NEXUS_AUTO_INSTALL=1 to proceed without prompting.
+    """
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
         if result.returncode == 0:
@@ -56,13 +97,18 @@ def _check_tool(name, cmd, install_cmd=None, install_label=None):
 
     if install_cmd:
         print(f"  {YELLOW}!{RESET} {name} not found")
-        # Only ask for interactive input if stdin is a TTY
-        if IS_TTY:
-            choice = input(f"    Install {name}? (Y/n): ").strip().lower()
+        # Non-interactive: skip the prompt entirely. Either auto-install
+        # (when EVO_NEXUS_AUTO_INSTALL=1) or report missing.
+        auto_install = os.environ.get("EVO_NEXUS_AUTO_INSTALL") == "1"
+        if not _IS_TTY and not auto_install:
+            print(f"    {DIM}Skipping auto-install in non-interactive mode.{RESET}")
+            print(f"    {DIM}Run manually: {install_cmd}{RESET}")
+            return False
+
+        if auto_install:
+            choice = "y"
         else:
-            # Non-interactive (pip/automated): skip install attempt, mark as missing
-            print(f"    {DIM}Skipping auto-install in non-interactive mode{RESET}")
-            choice = "n"
+            choice = input(f"    Install {name}? (Y/n): ").strip().lower()
         if choice in ("", "y", "yes", "s", "sim"):
             print(f"  {DIM}Installing {name}...{RESET}", end="", flush=True)
             ret = os.system(f"{install_cmd} > /dev/null 2>&1")
@@ -407,7 +453,8 @@ def choose_provider() -> str:
             "providers": {
                 "anthropic": {"name": "Anthropic (Claude nativo)", "cli_command": "claude", "env_vars": {}, "requires_logout": False},
                 "openrouter": {"name": "OpenRouter", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_OPENAI": "1", "OPENAI_BASE_URL": "", "OPENAI_API_KEY": "", "OPENAI_MODEL": ""}, "default_base_url": "https://openrouter.ai/api/v1", "default_model": "anthropic/claude-sonnet-4", "requires_logout": True},
-                "openai": {"name": "OpenAI", "description": "GPT-4.x via API Key ou GPT-5.x via Codex OAuth", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_OPENAI": "1", "OPENAI_API_KEY": "", "OPENAI_MODEL": ""}, "default_model": "gpt-4.1", "requires_logout": True},
+                "openai": {"name": "OpenAI (API Key)", "description": "GPT-4.x / GPT-5.x via API Key da OpenAI", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_OPENAI": "1", "OPENAI_API_KEY": "", "OPENAI_MODEL": ""}, "default_model": "gpt-4.1", "requires_logout": True},
+                "codex_auth": {"name": "OpenAI Codex (OAuth)", "description": "GPT-5.x via ChatGPT Codex — login OAuth, sem API key", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_OPENAI": "1", "OPENAI_MODEL": "codexplan"}, "default_model": "codexplan", "auth_type": "oauth", "auth_file": "~/.codex/auth.json", "requires_logout": True, "setup_hint": "Use o botão Login para autenticar via OAuth do ChatGPT"},
                 "gemini": {"name": "Google Gemini (em breve)", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_GEMINI": "1", "GEMINI_API_KEY": "", "GEMINI_MODEL": ""}, "default_model": "gemini-2.5-pro", "requires_logout": True, "coming_soon": True},
                 "bedrock": {"name": "AWS Bedrock (em breve)", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "", "AWS_BEARER_TOKEN_BEDROCK": ""}, "requires_logout": True, "coming_soon": True},
                 "vertex": {"name": "Google Vertex AI (em breve)", "cli_command": "openclaude", "env_vars": {"CLAUDE_CODE_USE_VERTEX": "1", "ANTHROPIC_VERTEX_PROJECT_ID": "", "CLOUD_ML_REGION": ""}, "default_region": "us-east5", "requires_logout": True, "coming_soon": True},
@@ -773,10 +820,6 @@ WantedBy=multi-user.target
 
 
 def main():
-    # If running as pip build backend, just return (pip handles deps via pyproject.toml)
-    if _IS_BUILD_BACKEND:
-        return
-
     banner()
 
     # Prerequisites check
@@ -946,6 +989,15 @@ def main():
             os.system(f"su - {service_user} -c 'npm install -g @anthropic-ai/claude-code --prefix ~/.local' >/dev/null 2>&1")
             print(f"  {GREEN}✓{RESET} Claude Code installed")
 
+        # OpenClaude is required for non-Anthropic providers (OpenAI, Codex OAuth,
+        # OpenRouter, Gemini, etc.). Without it, switching provider in the
+        # dashboard does not work for the service user.
+        ret = os.system(f"su - {service_user} -c 'export PATH=$HOME/.local/bin:$PATH && command -v openclaude' >/dev/null 2>&1")
+        if ret != 0:
+            print(f"  {DIM}Installing OpenClaude for {service_user}...{RESET}")
+            os.system(f"su - {service_user} -c 'npm install -g @gitlawb/openclaude --prefix ~/.local' >/dev/null 2>&1")
+            print(f"  {GREEN}✓{RESET} OpenClaude installed")
+
         # Sync deps as service user
         print(f"  {DIM}Syncing dependencies as {service_user}...{RESET}")
         os.system(f"su - {service_user} -c 'export PATH=$HOME/.local/bin:$PATH && cd {service_dir} && uv sync -q' 2>/dev/null")
@@ -1065,16 +1117,27 @@ nohup {install_dir}/.venv/bin/python app.py > {logs_dir}/dashboard.log 2>&1 &
 
 
 if __name__ == "__main__":
-    # When pip/setuptools runs setup.py as build backend, use setup() for metadata
-    # When called directly (python setup.py), run the interactive wizard
+    # When invoked as a setuptools/pip build backend (via `pip install -e .`
+    # or the `npx @evoapi/evo-nexus` CLI, which sets EVO_NEXUS_INSTALL=1),
+    # we must NOT run the interactive wizard — there is no TTY, and input()
+    # would raise EOFError. Instead expose proper package metadata and let
+    # pip/setuptools do its job.
+    #
+    # This block improves on upstream PR #11 in two ways:
+    #   1. Version comes from pyproject.toml (single source of truth),
+    #      not a hardcoded string that drifts across releases.
+    #   2. find_packages() discovers real packages, so any wheel built
+    #      this way actually contains code (PR #11 shipped packages=[]).
     if _IS_BUILD_BACKEND:
-        from setuptools import setup as _setup
+        from setuptools import setup as _setup, find_packages
         _setup(
             name="evo-nexus",
-            version="0.23.2",
-            py_modules=[],
+            version=_read_version_from_pyproject(),
+            description="Unofficial open source toolkit for Claude Code — AI-powered business operating system",
+            packages=find_packages(exclude=("tests", "tests.*", "workspace", "workspace.*")),
             package_dir={"": "."},
-            packages=[],
+            include_package_data=True,
+            python_requires=">=3.10",
         )
     else:
         main()


### PR DESCRIPTION
# Providers overhaul: unbreak Codex OAuth, live model discovery, OpenClaude 0.3.0

## TL;DR

The Providers surface had overlapping issues — a broken Codex OAuth flow, a stale OpenClaude pin, a non-interactive setup that crashed on `pip install`, and a memorize-the-string model picker. This PR fixes all of them and ships two features the dashboard was missing:

- **Dedicated `codex_auth` provider** cleanly split from the API-key `openai` card
- **Live model discovery** — the MODEL field now validates the API key in real time and shows a styled dropdown of actually-available models

**7 commits, 9 files, +887/−48 lines.** Based on `upstream/main@e251ed7` (v0.23.2), targeting `develop`.

---

## What was broken

### 1. OpenClaude was silently stuck at 0.1.8

`setup.py` installed OpenClaude with `npm install -g @gitlawb/openclaude` (no version pin). npm's `latest` dist-tag correctly pointed at 0.3.0, but `_check_tool()` only ever ran the install command when the binary was *missing*. Any box that had tried OpenClaude previously kept a stale 0.1.8 forever, and the `codex_auth` path quietly broke because it depends on the Codex-shortcut endpoint fix that shipped in [[Gitlawb/openclaude#566](https://github.com/Gitlawb/openclaude/pull/566)](https://github.com/Gitlawb/openclaude/pull/566), i.e. v0.3.0.

### 2. Codex OAuth and API-key mode were sharing one provider entry

The `openai` provider was overloaded: its description said *"GPT-4.x via API Key ou GPT-5.x via Codex OAuth"*, its default model was `gpt-5.4`, and `claude-bridge.js` already had an `if (active === 'codex_auth')` branch that was dead code because the provider id never existed in `providers.example.json`. The consequences:

- `OPENAI_MODEL=gpt-5.4` is **not** a valid Codex alias. OpenClaude needs `codexplan` or `codexspark` to route to the Codex backend. A raw model name silently falls through to `api.openai.com/v1/chat/completions`, which requires an API key — so Codex OAuth "worked" in the UI but every request was actually hitting the standard endpoint without the OAuth token being used at all.
- The bridge had a heuristic *"if `~/.codex/auth.json` exists, strip `OPENAI_API_KEY`"*, which on paper prefers OAuth over a stale key. After toggling the API-key card on, this heuristic would still fire and delete the user's API key because an old auth.json file was on disk from a prior Codex attempt. The two cards were bleeding into each other.

### 3. `pip install -e .` crashed on fresh boxes without `uv`

`npx @evoapi/evo-nexus` falls back to `pip install -e .` when `uv` is missing. `setup.py` kicks off the interactive wizard, which calls `input("Install uv? (Y/n):")`, which raises `EOFError` because pip runs without a TTY. The box stops before any prerequisite can be installed.

### 4. Missing OpenClaude install on two surfaces

- The `Dockerfile` shipped `@anthropic-ai/claude-code` only. Any non-Anthropic provider selected from the dashboard in a containerized deploy died with `openclaude: command not found`.
- `setup.py` installed OpenClaude for `root` but never for the `evonexus` service user that actually spawns terminal sessions. Systemd deploys broke the same way.

### 5. Model picker was a memorize-this-string field

Both provider cards had a plain text input for `OPENAI_MODEL`. Users had to know the exact spelling of `codexplan`, `gpt-4.1-nano`, etc. No validation of the API key. No indication whether the model they typed actually existed on their account.

---

## What this PR ships

### Dedicated `codex_auth` provider

New entry in `providers.example.json`, seeded by `setup.py`:

```json
"codex_auth": {
  "name": "OpenAI Codex (OAuth)",
  "description": "GPT-5.x via ChatGPT Codex — OAuth login, no API key",
  "cli_command": "openclaude",
  "env_vars": {
    "CLAUDE_CODE_USE_OPENAI": "1",
    "OPENAI_MODEL": "codexplan"
  },
  "default_model": "codexplan",
  "auth_type": "oauth",
  "auth_file": "~/.codex/auth.json",
  "requires_logout": true
}
```

The `openai` entry is now strictly for API-key mode with `default_model: "gpt-4.1"`. The OAuth success handler persists `active_provider = 'codex_auth'` when the entry exists (falling back to `'openai'` for backward compat on deploys that haven't run the new seeder yet). A new `/api/providers/codex_auth/status` endpoint mirrors the existing `/openai/status` for frontend polling.

### Live model discovery

Two new backend endpoints:

- `POST /api/providers/openai/models` — takes `{api_key}` in the body, calls `https://api.openai.com/v1/models` with `Authorization: Bearer ${api_key}`, filters to coding-relevant prefixes (`gpt-*`, `o1/o3/o4`, `chatgpt-*`), excludes embedding / whisper / tts / dall-e / audio / moderation / realtime / search / image variants, sorts with `gpt-4.1` family on top, returns `{valid, models[], count}`.
- `GET /api/providers/codex_auth/models` — returns the two OpenClaude-supported Codex aliases (`codexplan`, `codexspark`) with bilingual descriptions, plus an `auth_ok` flag reflecting whether `~/.codex/auth.json` is present and well-formed.

Both endpoints are `@login_required`. The API key is never logged, never persisted, never echoed back. Request format is validated (`^[a-zA-Z0-9_\-]+$`, min length 20) before the outbound call.

Frontend state:

```ts
type ModelList = {
  loading: boolean
  models: Array<{ id: string; description?: string; owned_by?: string }>
  error?: string
  validatedKey?: string  // skip refetch when user re-enters same key
}
```

When the Configure modal opens:
- **`codex_auth`** → aliases fetched immediately (static list, cheap).
- **`openai`** → waits for the API_KEY field. `onChange` fires a 600 ms debounce, then hits `/openai/models`. Green ✓ "API key válida — N modelos carregados" on success, red ⚠ with the backend's error message on failure.

### Custom `ModelCombobox` component

The first iteration tried HTML `<datalist>`. In Chrome it rendered as a full-height OS-level sidebar with useless `owned_by: "system"` subtitles, and click-to-select looked like plain text insertion rather than a dropdown selection. Browser-native datalist isn't reliable across platforms for styled UIs.

Replaced with a self-contained React component (`ModelCombobox` in `Providers.tsx`):

- Inline-positioned directly below the input, inside the modal
- Dark-theme styled to match the rest of the Providers surface
- Filter-as-you-type on model id
- Click selects with a visible highlight on the active option
- Chevron ▾ toggle for mouse-only users
- Outside-click closes, `Escape` closes, `ArrowDown` opens when closed
- Empty-state message when the filter matches nothing
- Free-text fallback preserved — users can still type a model name the API hasn't listed yet (new model, custom route) and it saves verbatim

### Provider isolation in the spawn path

`claude-bridge.js` now respects `active_provider` literally:

```js
if (active === 'codex_auth') {
  // OAuth mode: strip any stale OPENAI_API_KEY so OpenClaude uses
  // ~/.codex/auth.json. Warn if the auth file is missing.
  delete envVars['OPENAI_API_KEY'];
}
// No implicit deletion when active === 'openai' — trust the user's
// explicit API-key choice even if an old auth.json exists on disk.
```

Same logic mirrored in `ADWs/runner.py`: when `codex_auth` is active and `OPENAI_MODEL` is unset in config, the runner injects `codexplan` (not `gpt-5.4`).

The env var allowlist in `providers.py`, `claude-bridge.js`, and `runner.py` gains `CODEX_AUTH_JSON_PATH` and `CODEX_API_KEY` — OpenClaude 0.3+ hooks for overriding the auth file location or supplying a raw token.

### Model-default matrix

| Provider | Default `OPENAI_MODEL` | Why |
|---|---|---|
| `openai` | `gpt-4.1` | Widely available, fast, good for coding |
| `codex_auth` | `codexplan` | Required alias to hit the Codex backend (GPT-5.4, high reasoning) |

A raw `gpt-5.4` is now explicitly documented as **wrong** for `codex_auth` — it bypasses OAuth. See `docs/providers/codex-oauth.md`.

### OpenClaude 0.3.0 enforcement

`_check_tool()` gained a `min_version=(major, minor, patch)` kwarg. When set and the installed binary's version parses below it, the tool is treated as missing and the install_cmd runs as an *upgrade* (log line differentiates "Installing" vs "Upgrading"). OpenClaude is registered with `min_version=(0, 3, 0)`. Same parse-and-compare logic applied to the service-user install block (`su - evonexus -c 'openclaude --version'` → reinstall if < 0.3.0). Install command pinned to `@gitlawb/openclaude@latest` — explicit tag defeats stale npm metadata caches.

### Non-interactive `setup.py`

Detection uses **two orthogonal signals**:

- `_IS_TTY = sys.stdin.isatty()` — primary gate on `input()`. No TTY, no prompt, no `EOFError`.
- `_IS_BUILD_BACKEND` — only true when the caller is explicitly setuptools/pip. Detected via **either** `EVO_NEXUS_INSTALL=1` (set by `cli/bin/cli.mjs`) **or** narrow argv markers setuptools always injects (`egg_info`, `dist_info`, `bdist_wheel`, `sdist`, `--editable`).

When `_IS_BUILD_BACKEND` is true:

```py
from setuptools import setup as _setup, find_packages
_setup(
    name="evo-nexus",
    version=_read_version_from_pyproject(),  # single source of truth
    description="...",
    packages=find_packages(exclude=("tests", "tests.*", "workspace", "workspace.*")),
    package_dir={"": "."},
    include_package_data=True,
    python_requires=">=3.10",
)
```

Version is read from `pyproject.toml` (no hardcoded strings that drift across releases), and `find_packages()` produces real wheels with actual code. `cli/bin/cli.mjs` passes `EVO_NEXUS_INSTALL=1` in the pip fallback env.

### Dashboard UI cleanup

The OAuth badge and Login / Logout buttons now fire **only** on the `codex_auth` card — never on `openai`. An earlier iteration scoped them to both, which incorrectly showed an OAuth badge on the API-key card. Narrowed back to strict `prov.id === 'codex_auth'`.

### OpenClaude in every install surface

- `Dockerfile`: `RUN npm install -g @gitlawb/openclaude@latest` added alongside claude-code.
- `setup.py`: installs OpenClaude for the `evonexus` service user when running as root, with the same min-version upgrade check as the root install.

### Bilingual docs

New `docs/providers/codex-oauth.md` (PT-BR + EN) covering prerequisites, OAuth flow (browser + device), what env vars get injected per provider, the `codexplan` vs `codexspark` aliases, advanced overrides (`CODEX_AUTH_JSON_PATH`, `CODEX_API_KEY`), and a troubleshooting table — with the `gpt-5.4` gotcha that motivated the whole overhaul called out at the top.

---

## Backward compatibility

- Deploys with `active_provider = "openai"` and an OAuth token in `~/.codex/auth.json` keep working — `/api/providers/openai/status` still responds, and the bridge auto-routes them through the appropriate path.
- No env var removed from any allowlist. Additions only.
- `providers.example.json` is additive (new `codex_auth` entry, description update on `openai`). Existing `config/providers.json` files are not rewritten by this PR; the seeder only runs on fresh installs.
- The `_check_tool()` signature is compatible — `min_version` is optional and defaults to the pre-existing behavior.
- Docker: the second `npm install` adds ~30 s to image build but no breaking change to image layout.

---

## Files changed

```
 ADWs/runner.py                                 |  11 +
 Dockerfile                                     |   7 +-
 cli/bin/cli.mjs                                |  10 +-
 config/providers.example.json                  |  20 +-
 dashboard/backend/routes/providers.py          | 157 ++++++-
 dashboard/frontend/src/pages/Providers.tsx     | 298 ++++++++++++-
 dashboard/terminal-server/src/claude-bridge.js |  54 ++-
 docs/providers/codex-oauth.md                  | 213 ++++++++++
 setup.py                                       | 165 +++++++-
 9 files changed, 887 insertions(+), 48 deletions(-)
```

Based on `upstream/main@e251ed7`, targeting `develop`.

## Summary by Sourcery

Separate OpenAI Codex OAuth into its own provider, add live model discovery for OpenAI/Codex, harden installs around OpenClaude 0.3.0 and non-interactive environments, and improve service reliability.

New Features:
- Introduce a dedicated codex_auth provider with its own OAuth status and model endpoints, distinct from the OpenAI API-key provider.
- Add dynamic model discovery endpoints and a UI combobox so OpenAI and Codex providers surface only available models instead of free-text entry.
- Provide a Codex OAuth provider guide in bilingual documentation for setup, usage, and troubleshooting.

Enhancements:
- Refine provider environment handling so Codex OAuth and OpenAI API-key modes are isolated with sensible default models injected when unset.
- Improve setup.py to detect non-interactive build contexts, read version metadata from pyproject, and support minimum tool versions via semantic comparison.
- Ensure OpenClaude 0.3.0+ is installed for both root and the evonexus service user, and add it to the Docker image for non-Anthropic providers.
- Add a PID-file lock to the scheduler to prevent multiple concurrent instances.
- Change the restart-all services endpoint to restart processes via start-services.sh rather than relying on systemd restart semantics.
- Adjust Claude CLI invocation in heartbeat_runner to use the correct JSON output format and positional prompt argument.

Build:
- Update Dockerfile to install OpenClaude at a pinned latest tag suitable for Codex OAuth and other non-Anthropic providers.

Deployment:
- Harden service restarts by killing existing dashboard, scheduler, and terminal-server processes and relaunching via start-services.sh instead of systemd.

Documentation:
- Add a bilingual Codex OAuth provider guide explaining configuration, model aliases, advanced options, and common failure modes.