### PR TITLE
feat(deploy): Docker Swarm + Portainer + Traefik production overlay (additive)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,86 @@
+name: Build & Publish Docker Images (Swarm)
+
+# Builds evo-nexus-runtime and evo-nexus-dashboard images using the
+# Swarm-specific Dockerfiles (Dockerfile.swarm and Dockerfile.swarm.dashboard)
+# and pushes them to GitHub Container Registry (ghcr.io). The upstream
+# Dockerfile and Dockerfile.dashboard are intentionally NOT used here:
+# they are for local `docker compose up`, while these variants carry the
+# Swarm-specific bootstrap (entrypoint.sh, start-dashboard.sh, terminal-
+# server native build, both CLIs on PATH).
+#
+# Triggers:
+#   * push to main            -> builds + publishes :latest
+#   * push of a version tag   -> builds + publishes :vX.Y.Z and :latest
+#   * manual dispatch         -> builds without pushing (dry-run)
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  build-and-push:
+    name: Build & push ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: evo-nexus-runtime
+            dockerfile: Dockerfile.swarm
+          - image: evo-nexus-dashboard
+            dockerfile: Dockerfile.swarm.dashboard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lowercase owner for ghcr.io
+        id: owner
+        run: echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'workflow_dispatch'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner_lc }}/${{ matrix.image }}
+          # Boa prática: publicar :latest junto com a tag versionada sempre
+          # que um release (tag v*) for empurrado. Push para a branch main
+          # sem tag também atualiza :latest.
+          flavor: |
+            latest=${{ github.ref_type == 'tag' || github.ref == 'refs/heads/main' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'workflow_dispatch' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/Dockerfile.swarm
+++ b/Dockerfile.swarm
@@ -1,0 +1,84 @@
+# ============================================================================
+# Dockerfile.swarm — EvoNexus runtime para Docker Swarm / Portainer
+#
+# This is a Swarm-specific variant of the upstream Dockerfile. It matches
+# the upstream feature set (Python + Node + claude + openclaude + gh +
+# todoist) but adds a bootstrap entrypoint that:
+#   * Creates /workspace/config on first boot from baked-in defaults
+#   * Sources /workspace/config/.env so UI-edited values become env vars
+#   * Generates EVONEXUS_SECRET_KEY on first boot if absent
+#   * Supports Docker Secrets (_FILE pattern, /run/secrets/*)
+#   * Waits for ANTHROPIC_API_KEY if REQUIRE_ANTHROPIC_KEY=1 (no crash-loop)
+#
+# The upstream Dockerfile and docker-compose.yml are NOT modified; local
+# `docker compose up` and `make setup` on VPS continue to work as before.
+# ============================================================================
+FROM node:22-slim AS base
+
+# System deps — mirrors upstream Dockerfile line-for-line
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv \
+        curl ca-certificates git jq screen openssl \
+        gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python package manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install Claude Code CLI (default provider)
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install OpenClaude CLI — pinned to @latest which is ≥0.3.0 (the first
+# release with the Codex shortcut endpoint fix that resolves the
+# api.responses.write scope issue). Upstream setup.py also installs @latest
+# so Swarm and VPS behavior stay aligned.
+RUN npm install -g @gitlawb/openclaude@latest
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Todoist CLI (used by int-todoist skill)
+RUN npm install -g todoist-ts-cli
+
+# Timezone (default America/Sao_Paulo, override via TZ env var)
+ENV TZ=America/Sao_Paulo
+RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo "${TZ}" > /etc/timezone
+
+WORKDIR /workspace
+
+# Python deps (cache-friendly layer)
+COPY pyproject.toml uv.lock ./
+RUN uv venv .venv && uv sync
+
+# Application code — everything else
+COPY . .
+
+# Stash first-boot defaults somewhere the bootstrap entrypoint can find them.
+# /workspace/config is a writable volume in Swarm; on first boot entrypoint.sh
+# copies these seeds into it so the dashboard has something to edit.
+RUN mkdir -p /workspace/_defaults/config \
+    && if [ -d /workspace/config ]; then \
+          cp -a /workspace/config/. /workspace/_defaults/config/ 2>/dev/null || true; \
+       fi \
+    && if [ -f /workspace/.env.example ]; then \
+          cp /workspace/.env.example /workspace/_defaults/.env.example; \
+       fi
+
+# Bootstrap / secrets-to-env / wait-for-config wrapper
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# OCI metadata
+LABEL org.opencontainers.image.title="evo-nexus-runtime" \
+      org.opencontainers.image.description="EvoNexus runtime for Swarm (telegram/scheduler/ad-hoc routines)" \
+      org.opencontainers.image.source="https://github.com/EvolutionAPI/evo-nexus" \
+      org.opencontainers.image.licenses="MIT"
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/Dockerfile.swarm.dashboard
+++ b/Dockerfile.swarm.dashboard
@@ -1,0 +1,120 @@
+# ============================================================================
+# Dockerfile.swarm.dashboard — EvoNexus Dashboard para Docker Swarm
+#
+# The upstream Dockerfile.dashboard is Python-only (Flask + React). That
+# is enough for local dev but the embedded terminal — a core feature —
+# needs the Node terminal-server running inside the container, plus
+# the `claude` and `openclaude` binaries that sessions spawn.
+#
+# Three stages:
+#   Stage 1 (frontend-build):   compiles React with Vite (node:22-alpine)
+#   Stage 2 (terminal-build):   compiles terminal-server's native deps
+#                               (node-pty needs python3 + g++ + make)
+#   Stage 3 (runtime):          python:3.12-slim + Node.js 22 + uv +
+#                               claude-code + openclaude@latest +
+#                               start-dashboard.sh (Flask + terminal-server)
+#
+# Runtime image stays lean: no build toolchain, just the compiled
+# node_modules from stage 2.
+# ============================================================================
+
+# ---- Stage 1: Frontend build ---------------------------------------------
+FROM node:22-alpine AS frontend-build
+WORKDIR /frontend
+COPY dashboard/frontend/package.json dashboard/frontend/package-lock.json* ./
+RUN npm install
+COPY dashboard/frontend/ ./
+RUN npm run build
+
+# ---- Stage 2: Terminal-server native deps --------------------------------
+# node-pty uses node-gyp to compile a C++ addon at install time. That
+# requires python3 + make + g++ which we don't want in the final image.
+FROM node:22-slim AS terminal-build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /terminal
+COPY dashboard/terminal-server/package.json dashboard/terminal-server/package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+# ---- Stage 3: Python + Node runtime --------------------------------------
+FROM python:3.12-slim AS runtime
+
+# System deps: curl for healthcheck + Node.js 22 for terminal-server binary.
+# We use NodeSource so the final image is clean (no build toolchain).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg openssl \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv (Python package manager used by Evo Nexus)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Both CLIs — the Providers page in the UI switches between them at runtime.
+# @gitlawb/openclaude@latest is pinned to the npm dist-tag which as of the
+# current fix is ≥0.3.0 (first version with the Codex shortcut endpoint).
+RUN npm install -g \
+        @anthropic-ai/claude-code \
+        @gitlawb/openclaude@latest
+
+# Timezone
+ENV TZ=America/Sao_Paulo
+RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo "${TZ}" > /etc/timezone
+
+WORKDIR /workspace
+
+# Python deps (cached layer — only rebuilt when pyproject.toml or uv.lock change)
+COPY pyproject.toml uv.lock ./
+RUN uv venv .venv && uv sync --no-dev
+
+# Application code
+COPY dashboard/       dashboard/
+COPY social-auth/     social-auth/
+COPY scheduler.py     ./
+COPY .claude/         .claude/
+COPY memory/          memory/
+COPY ADWs/            ADWs/
+COPY config/          config/
+COPY Makefile         ./
+COPY .env.example     ./
+
+# Pre-compiled terminal-server node_modules from stage 2
+COPY --from=terminal-build /terminal/node_modules dashboard/terminal-server/node_modules
+
+# Built frontend from stage 1
+COPY --from=frontend-build /frontend/dist dashboard/frontend/dist
+
+# SQLite data dir (matches upstream Dockerfile.dashboard)
+RUN mkdir -p dashboard/data
+
+# First-boot defaults for the bootstrap entrypoint (writable config volume)
+RUN mkdir -p /workspace/_defaults/config \
+    && cp -a /workspace/config/. /workspace/_defaults/config/ 2>/dev/null || true \
+    && cp /workspace/.env.example /workspace/_defaults/.env.example 2>/dev/null || true
+
+# Bootstrap wrapper (config volume + source .env + wait-for-key)
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Multi-process supervisor (Flask on :8080 + terminal-server on :32352)
+COPY start-dashboard.sh /usr/local/bin/start-dashboard.sh
+RUN chmod +x /usr/local/bin/start-dashboard.sh
+
+# OCI metadata
+LABEL org.opencontainers.image.title="evo-nexus-dashboard" \
+      org.opencontainers.image.description="EvoNexus Dashboard for Swarm (Flask + React + embedded CLI terminal)" \
+      org.opencontainers.image.source="https://github.com/EvolutionAPI/evo-nexus" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV EVONEXUS_PORT=8080
+ENV TERMINAL_SERVER_PORT=32352
+EXPOSE 8080 32352
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -fsS "http://localhost:${EVONEXUS_PORT}/api/version" || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/local/bin/start-dashboard.sh"]

--- a/README.swarm.md
+++ b/README.swarm.md
@@ -1,0 +1,168 @@
+# EvoNexus on Docker Swarm — Deploy Guide
+
+This repo supports three independent deployment paths. Each one uses a
+different set of files, and none of them interferes with the others:
+
+| Path | Files used | Who it's for |
+|---|---|---|
+| **VPS bare-metal** — `git clone` + `make setup` + `install-service.sh` | `setup.py`, `install-service.sh`, `Makefile` | Single-VPS installs with systemd |
+| **Local dev with Docker Compose** — `docker compose up` | `Dockerfile`, `Dockerfile.dashboard`, `docker-compose.yml` | Local development, single-machine demos |
+| **Production on Docker Swarm** — Portainer / Traefik | `Dockerfile.swarm`, `Dockerfile.swarm.dashboard`, `evonexus.stack.yml` | Multi-node production behind a reverse proxy |
+
+This guide covers the third path. The first two are documented elsewhere
+and are **not** modified by the Swarm overlay.
+
+## Architecture
+
+Three Swarm services in one stack:
+
+| Service | Image | Purpose |
+|---|---|---|
+| `evonexus_dashboard` | `evo-nexus-dashboard` | Flask + React + embedded terminal-server, exposed through Traefik |
+| `evonexus_telegram` | `evo-nexus-runtime` | Long-running `claude --channels plugin:telegram…` daemon |
+| `evonexus_scheduler` | `evo-nexus-runtime` | Background scheduler for ADW routines (`scheduler.py`) |
+
+Seven named volumes (auto-created by Portainer on first deploy):
+
+- `evonexus_config` — the UI-editable `.env` and providers config (writable)
+- `evonexus_workspace` — agent workspace (daily-logs, projects, finance, etc.)
+- `evonexus_dashboard_data` — dashboard SQLite
+- `evonexus_memory` — persistent agent memory
+- `evonexus_adw_logs` — routine execution logs
+- `evonexus_agent_memory` — per-agent scratch memory
+- `evonexus_codex_auth` — `~/.codex/auth.json` persisted across restarts
+
+One external overlay network (`traefik-public` by default — rename to match
+your Traefik setup).
+
+## UI-first configuration
+
+The stack intentionally ships **zero API keys and zero integration tokens**.
+Everything is configured through the dashboard after the first boot:
+
+- **Providers** (`/providers`) — Anthropic, OpenAI API Key, Codex OAuth, OpenRouter, Gemini, etc.
+- **Integrations** (`/integrations`) — Telegram, Stripe, Omie, Bling, Asaas, Fathom, Todoist, GitHub, Linear, Gmail, Calendar, YouTube, Instagram, LinkedIn, Evolution API, Evo CRM, …
+- **Env editor** — anything else
+
+When you save a value in the dashboard, it lands in `/workspace/config/.env`
+inside the `evonexus_config` volume. On the next container start, the
+entrypoint sources that `.env` so every process sees the value as a regular
+environment variable.
+
+## Runtime daemon services — what does and doesn't need its own container
+
+Only channels that maintain a persistent connection need a dedicated
+long-running service. External REST APIs do not.
+
+| Channel | Dedicated service? | Notes |
+|---|---|---|
+| Telegram | ✅ Included (`evonexus_telegram`) | Already in the stack |
+| Discord | Optional | Duplicate the `evonexus_telegram` block; swap `plugin:telegram` → `plugin:discord` |
+| iMessage | Optional | Same pattern; needs a BlueBubbles server on a Mac |
+| WhatsApp (Evolution API / Go) | ❌ Not needed | External HTTP API — run the `evolution_api` stack separately |
+| Stripe / Omie / Bling / Asaas / Fathom / Todoist | ❌ Not needed | External REST APIs, called on demand |
+| GitHub / Linear / Gmail / Calendar / YouTube / Instagram / LinkedIn | ❌ Not needed | OAuth via dashboard, REST calls on demand |
+| Evo CRM | ❌ Not needed | Reached via cross-stack HTTP over the shared Traefik network |
+
+## Deploy flow
+
+### Prerequisites
+
+- Docker Swarm initialized on at least one manager node.
+- A Traefik stack already running, attached to an external overlay network
+  (this guide assumes `traefik-public` — rename to match your setup).
+- Traefik configured with a `websecure` entrypoint and a certificate
+  resolver called `letsencryptresolver` (rename in the stack labels if
+  your resolver has a different name).
+- A DNS A record pointing `evonexus.<yourdomain>` to the Swarm ingress.
+- Docker images published to a registry (the included GitHub Actions
+  workflow publishes to `ghcr.io/<owner>/evo-nexus-{dashboard,runtime}`).
+- Either make the ghcr.io packages public, or run `docker login ghcr.io`
+  on every Swarm manager before deploying.
+
+### Steps
+
+1. **Build and publish the images.** Push a version tag (`vX.Y.Z`) or use
+   the Actions tab to run *Build & Publish Docker Images (Swarm)*
+   manually. The workflow builds both images in parallel and publishes
+   them with the version tag and `:latest`.
+
+2. **Open Portainer → Stacks → Add stack.**
+   - Name: `evonexus`
+   - Paste the contents of `evonexus.stack.yml`
+   - Replace the three placeholders: `OWNER` (your ghcr.io namespace),
+     `evonexus.example.com` (your hostname, two places), and
+     `traefik-public` (your Traefik overlay network name, several places)
+   - Click **Deploy**
+
+3. **Watch the containers come up.** `evonexus_dashboard` serves the SPA
+   immediately. `evonexus_telegram` and `evonexus_scheduler` will log
+   `waiting for ANTHROPIC_API_KEY` every 30 seconds — this is expected
+   until step 4.
+
+4. **Open `https://evonexus.<yourdomain>`** → Setup wizard → create the
+   admin user → Providers → pick and save a provider:
+   - **Anthropic** — paste `sk-ant-…` (default, no extra setup).
+   - **OpenAI API Key** — paste `sk-…` (create at
+     [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+     with *All* permissions, not *Restricted*).
+   - **Codex OAuth** — click the Login button and complete the ChatGPT
+     device flow. The token is written to the `evonexus_codex_auth`
+     volume and persists across restarts.
+
+5. **Wait ~30 seconds.** The telegram and scheduler services detect the
+   key on their next polling cycle and start running.
+
+6. **Integrations.** Configure channels and external APIs from
+   `/integrations`. Values land in the same config volume and are picked
+   up at container startup. After changing something the telegram daemon
+   uses, force-restart that service in Portainer
+   (`docker service update --force evonexus_telegram`).
+
+## Troubleshooting
+
+### Terminal says "Could not reach terminal-server"
+
+Confirm the dashboard container logs show both processes on boot:
+
+```
+[start-dashboard] terminal-server on :32352, Flask on :8080
+🚀 Terminal server running at http://localhost:32352
+ * Running on http://127.0.0.1:8080
+```
+
+If only Flask is running, the image is an old build — redeploy with the
+latest tag. Also verify that the Traefik router includes the
+`evonexus_terminal_strip` middleware (visible in the Traefik dashboard
+if you have one enabled).
+
+### telegram / scheduler crash-looping
+
+They should not crash — they wait for `ANTHROPIC_API_KEY` via the
+entrypoint's poll loop. If they exit immediately, the image predates
+the bootstrap entrypoint. Redeploy with a current tag.
+
+### Volumes lost after stack redeploy
+
+Portainer preserves named volumes across stack updates by default. If
+you removed and recreated the stack, data in `evonexus_config`,
+`evonexus_workspace`, etc. is gone unless you backed them up. Confirm
+with `docker volume ls` on the manager.
+
+## What is NOT changed from the main codebase
+
+The Swarm overlay is purely additive. Every upstream file is unmodified
+and continues to support the VPS and local Compose paths:
+
+- `Dockerfile`, `Dockerfile.dashboard`, `docker-compose.yml`
+- `setup.py`, `install-service.sh`, `Makefile`
+- `pyproject.toml`, `uv.lock`
+- All Python, React, skills, agents, ADWs, configs
+
+Swarm-specific files added by this overlay:
+
+- `Dockerfile.swarm`, `Dockerfile.swarm.dashboard`
+- `entrypoint.sh`, `start-dashboard.sh`
+- `evonexus.stack.yml`
+- `.github/workflows/docker-publish.yml`
+- `README.swarm.md` (this file)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# ============================================================================
+# entrypoint.sh — Bootstrap + source .env + wait-for-config wrapper
+#
+# Respects the UI-first config model EvoNexus ships upstream:
+#   * /workspace/config is a writable volume. The dashboard's Providers,
+#     Integrations, Settings and env-editor pages write there.
+#   * This entrypoint sources /workspace/config/.env on startup so the
+#     Claude CLI, Python code, and every library see the UI-configured
+#     values as regular environment variables.
+#   * Services that need ANTHROPIC_API_KEY (telegram, scheduler) wait in a
+#     30s-poll loop until the user sets it via the dashboard, instead of
+#     crash-looping and spamming the Swarm with restart attempts.
+#
+# The Docker Secrets / _FILE machinery is still honored for anyone who
+# wants it, but it is optional. The default stack file ships zero
+# secrets — every credential is configured through the dashboard after
+# the first deploy.
+# ============================================================================
+set -euo pipefail
+
+CONFIG_DIR=/workspace/config
+DEFAULTS_DIR=/workspace/_defaults
+
+# --- 1. Ensure writable dirs exist (volumes may mount empty) ---------------
+mkdir -p "$CONFIG_DIR" \
+         /workspace/workspace \
+         /workspace/memory \
+         /workspace/ADWs/logs \
+         /workspace/.claude/agent-memory \
+         /workspace/dashboard/data
+
+# --- 2. Bootstrap /workspace/config from image defaults (first boot only) --
+if [ -d "$DEFAULTS_DIR" ]; then
+    if [ ! -f "$CONFIG_DIR/.env" ]; then
+        if [ -f "$DEFAULTS_DIR/.env.example" ]; then
+            cp "$DEFAULTS_DIR/.env.example" "$CONFIG_DIR/.env"
+        else
+            touch "$CONFIG_DIR/.env"
+        fi
+    fi
+    for f in providers.example.json heartbeats.example.yaml; do
+        if [ -f "$DEFAULTS_DIR/config/$f" ] && [ ! -f "$CONFIG_DIR/$f" ]; then
+            cp "$DEFAULTS_DIR/config/$f" "$CONFIG_DIR/$f"
+        fi
+    done
+fi
+
+# --- 3. Ensure EVONEXUS_SECRET_KEY exists (Flask session signing) ----------
+# Without this, Flask invalidates every session on restart. We generate it
+# once on first boot and persist it in the same .env the UI edits.
+if ! grep -q '^EVONEXUS_SECRET_KEY=' "$CONFIG_DIR/.env" 2>/dev/null; then
+    echo "EVONEXUS_SECRET_KEY=$(openssl rand -hex 32)" >> "$CONFIG_DIR/.env"
+fi
+
+# --- 4. Symlinks so the app finds files at the paths it expects ------------
+ln -sfn "$CONFIG_DIR/.env" /workspace/.env
+if [ ! -e /workspace/CLAUDE.md ] && [ ! -L /workspace/CLAUDE.md ]; then
+    ln -sfn "$CONFIG_DIR/CLAUDE.md" /workspace/CLAUDE.md
+fi
+
+# --- 5. Source .env (UI-configured values become env vars) -----------------
+# Using `set -a` so every variable assigned here is auto-exported.
+set -a
+# shellcheck disable=SC1091
+. "$CONFIG_DIR/.env" 2>/dev/null || true
+set +a
+
+# --- 6. Optional: _FILE env vars (explicit Docker Secrets pattern) ---------
+for file_var in $(compgen -A variable | grep -E '_FILE$' || true); do
+    var="${file_var%_FILE}"
+    path_val="${!file_var:-}"
+    if [ -n "$path_val" ] && [ -f "$path_val" ]; then
+        export "${var}=$(cat "$path_val")"
+    fi
+done
+
+# --- 7. Optional: auto-discover /run/secrets/* -----------------------------
+if [ -d /run/secrets ]; then
+    for secret_file in /run/secrets/*; do
+        [ -f "$secret_file" ] || continue
+        var_name=$(basename "$secret_file" | tr '[:lower:]-' '[:upper:]_')
+        if [ -z "${!var_name:-}" ]; then
+            export "${var_name}=$(cat "$secret_file")"
+        fi
+    done
+fi
+
+# --- 8. Wait for required config (telegram, scheduler) ---------------------
+# The stack sets REQUIRE_ANTHROPIC_KEY=1 on services that can't run without
+# a key. Instead of crash-looping, we wait and re-read .env every 30s. When
+# the user saves the key in dashboard → Providers, it lands in .env and
+# we pick it up on the next iteration — no manual restart needed.
+if [ "${REQUIRE_ANTHROPIC_KEY:-0}" = "1" ]; then
+    while [ -z "${ANTHROPIC_API_KEY:-}" ]; do
+        echo "[$(date -Is)] waiting for ANTHROPIC_API_KEY — configure via dashboard → Providers" >&2
+        sleep 30
+        set -a
+        # shellcheck disable=SC1091
+        . "$CONFIG_DIR/.env" 2>/dev/null || true
+        set +a
+    done
+    echo "[$(date -Is)] ANTHROPIC_API_KEY detected — starting $*" >&2
+fi
+
+# --- 9. Hand off to the actual process -------------------------------------
+exec "$@"

--- a/evonexus.stack.yml
+++ b/evonexus.stack.yml
@@ -1,0 +1,163 @@
+## ============================================================================
+## EvoNexus — Portainer / Docker Swarm deployment stack
+##
+## Before deploying, replace the placeholders below with your own values:
+##   * ghcr.io/OWNER/...            → the ghcr.io namespace where your CI
+##                                    publishes the images (e.g. your fork,
+##                                    or `evolutionapi` once the images are
+##                                    published officially).
+##   * evonexus.example.com         → your public hostname (two places)
+##   * traefik-public               → the external Docker network shared
+##                                    with your Traefik stack (some setups
+##                                    call it `web`, `proxy`, etc.)
+##
+## Images are published automatically by .github/workflows/docker-publish.yml
+## on every version tag and on pushes to `main`.
+##
+## Everything else (provider API keys, integration tokens, channel
+## credentials) is configured through the dashboard UI after the first
+## deploy. The stack intentionally ships with zero secrets.
+## ============================================================================
+version: "3.7"
+
+services:
+
+  evonexus_dashboard:
+    image: ghcr.io/OWNER/evo-nexus-dashboard:latest  ## replace OWNER
+
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_dashboard_data:/workspace/dashboard/data
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+      - evonexus_codex_auth:/root/.codex
+
+    networks:
+      - traefik-public
+
+    environment:
+      ## Infrastructure-only env vars. Everything else (Anthropic, OpenAI,
+      ## Codex, Telegram, Stripe, Omie, Bling, Asaas, etc.) is configured
+      ## through the dashboard UI after the first boot. The entrypoint
+      ## generates EVONEXUS_SECRET_KEY automatically on first boot.
+      - TZ=America/Sao_Paulo
+      - EVONEXUS_PORT=8080
+      - TERMINAL_SERVER_PORT=32352
+      - FORWARDED_ALLOW_IPS=*
+
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1024M
+      labels:
+        - traefik.enable=1
+        - traefik.docker.network=traefik-public
+
+        ## Primary router — Flask / SPA on port 8080
+        - traefik.http.routers.evonexus_dashboard.rule=Host(`evonexus.example.com`)
+        - traefik.http.routers.evonexus_dashboard.entrypoints=websecure
+        - traefik.http.routers.evonexus_dashboard.priority=1
+        - traefik.http.routers.evonexus_dashboard.tls.certresolver=letsencryptresolver
+        - traefik.http.routers.evonexus_dashboard.service=evonexus_dashboard
+        - traefik.http.services.evonexus_dashboard.loadbalancer.server.port=8080
+        - traefik.http.services.evonexus_dashboard.loadbalancer.passHostHeader=true
+
+        ## Terminal-server router — Node PTY (HTTP + WebSocket) on port 32352.
+        ## Higher priority (10) so /terminal/* wins over the primary router.
+        ## The stripprefix middleware removes /terminal before forwarding
+        ## because the terminal-server exposes /api/... at its root.
+        - traefik.http.routers.evonexus_terminal.rule=Host(`evonexus.example.com`) && PathPrefix(`/terminal`)
+        - traefik.http.routers.evonexus_terminal.entrypoints=websecure
+        - traefik.http.routers.evonexus_terminal.priority=10
+        - traefik.http.routers.evonexus_terminal.tls.certresolver=letsencryptresolver
+        - traefik.http.routers.evonexus_terminal.service=evonexus_terminal
+        - traefik.http.routers.evonexus_terminal.middlewares=evonexus_terminal_strip
+        - traefik.http.middlewares.evonexus_terminal_strip.stripprefix.prefixes=/terminal
+        - traefik.http.services.evonexus_terminal.loadbalancer.server.port=32352
+        - traefik.http.services.evonexus_terminal.loadbalancer.passHostHeader=true
+
+  evonexus_telegram:
+    image: ghcr.io/OWNER/evo-nexus-runtime:latest  ## replace OWNER
+    command:
+      - "claude"
+      - "--channels"
+      - "plugin:telegram@claude-plugins-official"
+      - "--dangerously-skip-permissions"
+
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+      - evonexus_codex_auth:/root/.codex
+
+    networks:
+      - traefik-public
+
+    environment:
+      ## The entrypoint waits in a 30s polling loop until ANTHROPIC_API_KEY
+      ## appears in the .env file (i.e. until you configure the provider in
+      ## the dashboard). No crash-loop while the user is still onboarding.
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+
+    stdin_open: true
+    tty: true
+
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1024M
+
+  evonexus_scheduler:
+    image: ghcr.io/OWNER/evo-nexus-runtime:latest  ## replace OWNER
+    command: ["uv", "run", "python", "scheduler.py"]
+
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+      - evonexus_codex_auth:/root/.codex
+
+    networks:
+      - traefik-public
+
+    environment:
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1024M
+
+volumes:
+  evonexus_config:
+  evonexus_workspace:
+  evonexus_dashboard_data:
+  evonexus_memory:
+  evonexus_adw_logs:
+  evonexus_agent_memory:
+  evonexus_codex_auth:
+
+networks:
+  traefik-public:
+    external: true
+    name: traefik-public

--- a/start-dashboard.sh
+++ b/start-dashboard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ============================================================================
+# start-dashboard.sh — multi-process entrypoint for the dashboard container.
+#
+# The dashboard needs TWO processes running simultaneously:
+#   * Flask backend        → :8080   (/api/*, static SPA, OAuth, Providers...)
+#   * Node terminal-server → :32352  (/terminal/*, embedded CLI sessions)
+#
+# The React frontend calls /terminal/* on the same origin and expects the
+# reverse proxy (Traefik) to route it to :32352. If the terminal-server is
+# not running inside the container, every "open agent chat" click fails
+# with "Could not reach terminal-server".
+#
+# This wrapper starts both processes, then exec-waits. If EITHER dies, we
+# kill the other and exit with a non-zero code so Docker/Swarm restarts
+# the whole container — keeping both processes in sync.
+# ============================================================================
+set -euo pipefail
+
+TERMINAL_PORT="${TERMINAL_SERVER_PORT:-32352}"
+FLASK_PORT="${EVONEXUS_PORT:-8080}"
+
+echo "[start-dashboard] terminal-server on :${TERMINAL_PORT}, Flask on :${FLASK_PORT}"
+
+# Start terminal-server in the background
+node /workspace/dashboard/terminal-server/bin/server.js --port "${TERMINAL_PORT}" &
+TERMINAL_PID=$!
+
+# Start Flask in the background
+uv run python /workspace/dashboard/backend/app.py &
+FLASK_PID=$!
+
+# When this script exits for any reason, kill both children
+# shellcheck disable=SC2317  # invoked by trap below
+cleanup() {
+    echo "[start-dashboard] shutting down (terminal=${TERMINAL_PID}, flask=${FLASK_PID})"
+    kill "${TERMINAL_PID}" "${FLASK_PID}" 2>/dev/null || true
+    wait "${TERMINAL_PID}" 2>/dev/null || true
+    wait "${FLASK_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait for EITHER process to exit, then propagate the exit code. Swarm
+# restart_policy will bring the whole container back up on any failure.
+wait -n
+EXIT_CODE=$?
+echo "[start-dashboard] a child process exited with code ${EXIT_CODE}"
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary
 
This PR adds a **production-ready deployment path for Docker Swarm + Portainer + Traefik**, as a purely additive overlay on top of the existing VPS and local Compose paths. No upstream file is modified — the seven new files live alongside the ones already in the repo and are only consumed when you opt in.
 
The overlay has been verified end-to-end on a real three-node Swarm cluster behind a Traefik gateway: dashboard, embedded terminal, telegram daemon, scheduler, Codex OAuth device flow, and UI-first configuration all working. Happy to share logs or demo.
 
Companion PR (independent): #12 — *fix: Codex OAuth via OpenClaude 0.3+*. This Swarm PR works standalone with the Anthropic or OpenAI API Key providers; it only benefits from #12 when the operator chooses Codex OAuth as the active provider.
 
## Motivation
 
EvoNexus already ships a `Dockerfile`, a `Dockerfile.dashboard`, and a `docker-compose.yml` — all excellent for local development and single-host deploys. For production deployments on multi-node Docker Swarm with a shared Traefik reverse proxy (a common topology on hosted VPS fleets, Portainer environments, or self-hosted PaaS stacks), three gaps appear:
 
1. **Dashboard image has no terminal-server runtime.** The upstream `Dockerfile.dashboard` is Python-only. The embedded CLI terminal — which spawns `claude` / `openclaude` sessions via `node-pty` — needs Node.js at runtime plus the compiled native addon. In local Compose this isn't exercised because the terminal-server runs on the host, but in a prod container it has to live inside the image.
2. **No reverse-proxy-aware routing.** The terminal-server listens on port 32352 with a REST/WebSocket API rooted at `/api/*`. The dashboard SPA calls `/terminal/api/*` on the same origin, expecting the proxy to forward and strip the prefix. The upstream Compose setup doesn't need this because everything is on localhost.
3. **No first-boot UI-first bootstrap.** A multi-node Swarm deploy starts containers before the operator has a chance to configure anything. Without an entrypoint that (a) seeds a writable config volume from baked-in defaults, (b) sources the UI-edited `.env`, and (c) waits gracefully for the provider key to be set through the dashboard, services crash-loop while the admin is still in the Setup wizard.
This PR closes all three gaps without disturbing the existing paths.
 
## What's in this PR
 
Seven new files, grouped by concern:
 
### Container images
 
| File | Purpose |
|---|---|
| `Dockerfile.swarm` | Runtime image used by telegram, scheduler, and ad-hoc routines. Mirrors the upstream `Dockerfile` (python + uv + node + `@anthropic-ai/claude-code` + `@gitlawb/openclaude@latest` + `gh` + `todoist-ts-cli`) and adds the bootstrap entrypoint. |
| `Dockerfile.swarm.dashboard` | Three-stage build for the dashboard image: `frontend-build` (Vite), `terminal-build` (compiles `node-pty` with python3/make/g++), and a lean `runtime` (python:3.12-slim + Node 22 via NodeSource + uv + both CLIs + compiled node_modules from stage 2 + multi-process supervisor). |
 
### Entrypoints
 
| File | Purpose |
|---|---|
| `entrypoint.sh` | Idempotent bootstrap. Creates `/workspace/config` on first boot from `/workspace/_defaults` (baked into the image), sources `/workspace/config/.env` with `set -a` so UI-edited values become env vars, generates `EVONEXUS_SECRET_KEY` if missing, honors the `_FILE` pattern and `/run/secrets/*` for Docker Secrets, and on services that set `REQUIRE_ANTHROPIC_KEY=1` (telegram, scheduler), polls `.env` every 30s until the key arrives instead of crash-looping. |
| `start-dashboard.sh` | Minimal multi-process supervisor for the dashboard container. Spawns `node terminal-server/bin/server.js --port 32352` and `uv run python dashboard/backend/app.py` in the background, `wait -n`, traps EXIT/INT/TERM to kill both children on shutdown, and propagates the exit code so Swarm's restart policy takes over if either child dies. |
 
### Stack definition
 
| File | Purpose |
|---|---|
| `evonexus.stack.yml` | Portainer / Swarm stack: three services (`evonexus_dashboard`, `evonexus_telegram`, `evonexus_scheduler`), seven named volumes auto-created by Portainer, and an external Traefik overlay network. Two Traefik routers on the same host: priority-1 for the SPA (`:8080`), priority-10 for `PathPrefix(\`/terminal\`)` (`:32352`) with a `stripprefix` middleware so the terminal-server sees `/api/*` at its root. Zero API keys in the stack — everything goes through the dashboard UI. |
 
### CI
 
| File | Purpose |
|---|---|
| `.github/workflows/docker-publish.yml` | Matrix build of both images using the Swarm Dockerfiles, pushed to `ghcr.io/<owner>/evo-nexus-{dashboard,runtime}`. Publishes `:vX.Y.Z` plus `:latest` on every version tag and on pushes to `main`. Uses the auto-provided `GITHUB_TOKEN` with `packages: write` — no secrets setup required. |
 
### Docs
 
| File | Purpose |
|---|---|
| `README.swarm.md` | Standalone deploy guide: prerequisites, step-by-step Portainer deploy, first-boot UI walkthrough, which channels need dedicated daemons (Telegram/Discord/iMessage) vs which don't (everything over HTTP), troubleshooting for the three most common issues (terminal unreachable, crash-loop before provider setup, volumes lost). |
 
## What this PR does NOT change
 
Every upstream file is byte-identical to `develop`:
 
```
Dockerfile              (unchanged)
Dockerfile.dashboard    (unchanged)
docker-compose.yml      (unchanged)
setup.py                (unchanged)
install-service.sh      (unchanged)
Makefile                (unchanged)
pyproject.toml          (unchanged)
```
 
Verified by running `git diff --name-status develop..swarm-deployment`:
 
```
A .github/workflows/docker-publish.yml
A Dockerfile.swarm
A Dockerfile.swarm.dashboard
A README.swarm.md
A entrypoint.sh
A evonexus.stack.yml
A start-dashboard.sh
```
 
Only `A` (added) entries — zero `M` (modified) or `D` (deleted).
 
Concretely this means:
 
- **VPS installs** (`git clone` + `make setup` + `install-service.sh`) work exactly as before.
- **Local Compose** (`docker compose up`) works exactly as before.
- The Swarm overlay is opt-in: only consumers who reference `Dockerfile.swarm`, `Dockerfile.swarm.dashboard`, and `evonexus.stack.yml` use it.
## Design decisions worth flagging for review
 
- **Two separate Dockerfiles instead of editing the upstream ones.** The first draft tried to augment `Dockerfile.dashboard` with a `terminal-build` stage and a multi-process CMD, but any change to that file is picked up by `docker-compose.yml`, which would change the behavior of `docker compose up` for everyone. The `.swarm.` suffix keeps the two worlds orthogonal.
- **Placeholders in the stack file.** `evonexus.stack.yml` uses `ghcr.io/OWNER/...`, `evonexus.example.com`, and `traefik-public` as placeholders. The README documents the three replacements the operator needs to make. If maintainers prefer to point the default at `ghcr.io/evolutionapi/...` once the official images are published under the org namespace, that's a one-line sed.
- **`@gitlawb/openclaude@latest`.** Pinned to the npm dist-tag to inherit the same upgrade path as upstream `setup.py`. Rationale: both paths (VPS and Swarm) should converge on the same OpenClaude version, and the dist-tag is the single source of truth.
- **No Docker Secrets required by default, but supported.** The entrypoint honors the `_FILE` pattern and `/run/secrets/*` automatically for operators who prefer that workflow, but the default stack carries zero secrets and relies on the UI-first model. This matches the upstream design philosophy.
- **Terminal routing via `stripprefix`.** The first Traefik attempt just used `PathPrefix(\`/terminal\`)` without stripping, which made the terminal-server receive `/terminal/api/sessions/for-agent` and 404 silently. Adding the `stripprefix` middleware fixed it. The same pattern would also work with a path rewrite on the terminal-server itself, but the Traefik-side fix keeps the Node code path identical to the local dev one.
## How to test
 
On a fresh Swarm cluster:
 
1. Fork, let the CI publish the two images, make the packages public (or `docker login ghcr.io` on the manager).
2. In Portainer: Stacks → Add stack → paste `evonexus.stack.yml` → replace the three placeholders → Deploy.
3. Wait for the dashboard to come up (~30s). `telegram` and `scheduler` will log `waiting for ANTHROPIC_API_KEY` on a 30s loop.
4. Open the dashboard → Setup wizard → pick a provider → save.
5. Watch `telegram` and `scheduler` pick up the key on their next poll cycle and start running.
For a quicker smoke test without Swarm, the images can also be pulled and run standalone to confirm the entrypoint does not break the upstream command flow.
 
## Related
 
- Depends on nothing.
- Complements #12 (Codex OAuth 0.3+ fix) — users who want to run Codex OAuth as the active provider in the Swarm deploy will want both PRs merged, but this PR is independently mergeable and useful on its own with Anthropic or OpenAI API Key.
## Checklist
 
- [x] No upstream file modified
- [x] YAML and workflow validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Shell scripts pass `shellcheck` cleanly
- [x] Placeholders documented in the stack file and README
- [x] Three deploy paths (VPS, Compose, Swarm) remain independent

## Summary by Sourcery

Add an opt-in Docker Swarm production deployment overlay with Traefik/Portainer support, including new images, stack definition, and CI publishing, without changing existing deployment paths.

New Features:
- Introduce a Swarm-focused deployment stack file defining dashboard, telegram, and scheduler services with Traefik routing and persistent volumes.
- Add a Swarm deployment README documenting architecture, prerequisites, Portainer-based deploy steps, and troubleshooting.
- Provide a unified bootstrap entrypoint that seeds and sources a writable config volume, integrates with Docker secrets, and blocks dependent services until required keys are configured via the UI.
- Add a multiprocess dashboard start script to run Flask and the terminal-server together for reverse-proxy routing compatibility.

Enhancements:
- Add Swarm-specific Dockerfiles for runtime and dashboard images tailored for production clustering and terminal support.
- Introduce a GitHub Actions workflow to build and publish the Swarm Docker images to GitHub Container Registry on tags and main pushes.

CI:
- Add a Docker image build-and-publish workflow targeting Swarm-optimized images and tagging schemes in GitHub Container Registry.

Documentation:
- Add README.swarm.md describing the new Docker Swarm + Traefik production deployment path and its interaction with existing VPS and Compose setups.