### PR TITLE
feat(knowledge): add Google Gemini embedder (gemini-embedding-001 + 2-preview, MRL 768/1536/3072)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,3 +146,24 @@ AI_IMG_CREATOR_CF_TOKEN=
 AI_IMG_CREATOR_OPENROUTER_KEY=
 AI_IMG_CREATOR_GEMINI_KEY=
 
+# ── Knowledge Base — Embedder (optional) ────────────
+# The Knowledge Base (pgvector) uses one of three embedders:
+#   local   — sentence-transformers/paraphrase-multilingual-mpnet-base-v2 (default)
+#             768 dim · offline · ~420 MB model download on first use
+#   openai  — text-embedding-3-small / -3-large / ada-002
+#             1536 or 3072 dim · requires OPENAI_API_KEY
+#   gemini  — gemini-embedding-001 (stable) or gemini-embedding-2-preview
+#             768 / 1536 / 3072 dim (MRL) · requires GEMINI_API_KEY
+#
+# Most users should configure this via the dashboard at /knowledge/settings
+# rather than editing .env directly. The provider is locked once the first
+# connection is created.
+#
+# KNOWLEDGE_EMBEDDER_PROVIDER=local
+#
+# -- Gemini embedder ----------------------------------
+# Get a free key at https://aistudio.google.com/apikey (generous free tier).
+# GEMINI_API_KEY=AIzaSy...
+# KNOWLEDGE_GEMINI_MODEL=gemini-embedding-001   # or gemini-embedding-2-preview
+# KNOWLEDGE_GEMINI_DIM=768                      # 768 (default, aligns with local), 1536, or 3072
+

--- a/dashboard/backend/knowledge/embedders/base.py
+++ b/dashboard/backend/knowledge/embedders/base.py
@@ -3,6 +3,7 @@
 Registry logic:
     get_embedder("local")   → LocalEmbedder (sentence-transformers, 768 dim)
     get_embedder("openai")  → OpenAIEmbedder (text-embedding-3-small, 1536 dim)
+    get_embedder("gemini")  → GeminiEmbedder (gemini-embedding-001, MRL 768/1536/3072)
     get_embedder()          → reads KNOWLEDGE_EMBEDDER_PROVIDER env var (default "local")
 """
 
@@ -10,7 +11,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -26,11 +27,19 @@ class BaseEmbedder(ABC):
         """Embedding dimension for this provider."""
 
     @abstractmethod
-    def embed(self, texts: List[str]) -> List[List[float]]:
+    def embed(
+        self,
+        texts: List[str],
+        task_type: Optional[str] = None,
+    ) -> List[List[float]]:
         """Embed a list of texts.
 
         Args:
             texts: list of strings to embed (non-empty, each non-empty)
+            task_type: optional task hint used by providers that support it
+                (e.g. Gemini's RETRIEVAL_DOCUMENT, RETRIEVAL_QUERY,
+                SEMANTIC_SIMILARITY). Providers that do not support task
+                hints (local, OpenAI) ignore this parameter silently.
 
         Returns:
             List of float vectors, one per input text. Each vector has ``dim`` elements.
@@ -42,7 +51,7 @@ class BaseEmbedder(ABC):
 # ---------------------------------------------------------------------------
 
 def get_embedder(
-    provider: Literal["local", "openai", "auto"] = "auto",
+    provider: Literal["local", "openai", "gemini", "auto"] = "auto",
 ) -> BaseEmbedder:
     """Return an instantiated embedder for *provider*.
 
@@ -50,6 +59,7 @@ def get_embedder(
         "auto"   — reads KNOWLEDGE_EMBEDDER_PROVIDER env var (default "local")
         "local"  — LocalEmbedder (sentence-transformers)
         "openai" — OpenAIEmbedder (requires OPENAI_API_KEY)
+        "gemini" — GeminiEmbedder (requires GEMINI_API_KEY or GOOGLE_API_KEY)
 
     Raises:
         ValueError: unknown provider name
@@ -66,9 +76,12 @@ def get_embedder(
     if provider == "openai":
         from knowledge.embedders.openai_embedder import OpenAIEmbedder
         return OpenAIEmbedder()
+    if provider == "gemini":
+        from knowledge.embedders.gemini_embedder import GeminiEmbedder
+        return GeminiEmbedder()
 
     raise ValueError(
         f"Unknown embedder provider '{provider}'. "
-        "Valid options: 'local', 'openai'. "
+        "Valid options: 'local', 'openai', 'gemini'. "
         "Set KNOWLEDGE_EMBEDDER_PROVIDER in .env to change the default."
     )

--- a/dashboard/backend/knowledge/embedders/gemini_embedder.py
+++ b/dashboard/backend/knowledge/embedders/gemini_embedder.py
@@ -1,0 +1,216 @@
+"""Google Gemini embedder.
+
+Supports two models:
+  * ``gemini-embedding-001`` — text-only, 2048-token input, accepts ``task_type``.
+  * ``gemini-embedding-2-preview`` — multimodal preview, 8192-token input,
+    does NOT accept ``task_type`` (per Google docs, tasks are instructed
+    directly in the prompt for this model).
+
+Uses Matryoshka Representation Learning (MRL): output dim can be 768, 1536,
+or 3072. Default is 768 to align storage/index cost with the local MPNet
+embedder. For dims < 3072, vectors are L2-normalized on the client side
+(required per Google's embedding docs to preserve relative distances).
+
+Requires: ``pip install google-genai>=0.3``
+Requires: ``GEMINI_API_KEY`` or ``GOOGLE_API_KEY`` environment variable.
+
+Lazy import: ``google.genai`` is NOT imported at module load time so that
+deployments that never activate the Gemini provider do not pay the import
+cost and do not fail when the package is absent.
+
+Dimension mismatch note: if a Knowledge connection was configured with the
+``local`` embedder (768-dim), switching to Gemini with ``dim=1536`` or
+``dim=3072`` will break vector search. The configure wizard warns about
+this before persisting. This embedder does not enforce the check —
+the constraint lives in the API layer (``routes/knowledge.py``).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any, List, Optional
+
+from knowledge.embedders.base import BaseEmbedder
+
+try:
+    from google import genai  # type: ignore[import]
+    from google.genai import types as genai_types  # type: ignore[import]
+except ImportError:  # pragma: no cover - exercised only when SDK is missing
+    genai = None  # type: ignore[assignment,misc]
+    genai_types = None  # type: ignore[assignment,misc]
+
+
+_DEFAULT_MODEL = "gemini-embedding-001"
+_DEFAULT_DIM = 768
+
+# Allowed dimensions per Gemini MRL guidance.
+# Full range supported by the API is 128-3072; we expose only the three
+# values Google explicitly recommends ("for best quality and efficiency").
+_ALLOWED_DIMS = {768, 1536, 3072}
+
+# Model-specific native default dim (what the API returns when
+# output_dimensionality is omitted). Kept separate from _DEFAULT_DIM so the
+# evo-nexus default stays at 768 across both models for storage alignment.
+_MODEL_NATIVE_DIMS = {
+    "gemini-embedding-001": 768,
+    "gemini-embedding-2-preview": 768,
+}
+
+# Models that accept the ``task_type`` parameter. The 2-preview model does
+# not — task optimisation is expressed inline in the prompt instead.
+_MODELS_WITH_TASK_TYPE = {"gemini-embedding-001"}
+
+# Conservative client-side batch size. gemini-embedding-001 has a 2048-token
+# input limit; at ~50 tokens/chunk that's ~40 chunks/call. We stay at 20 for
+# safety across chunking strategies and to keep individual error blasts small.
+_BATCH_SIZE = 20
+
+
+def _clean(raw: Optional[str]) -> str:
+    """Strip surrounding whitespace/quotes that naive .env parsers may leak."""
+    if not raw:
+        return ""
+    return raw.strip().strip('"').strip("'")
+
+
+def _resolve_api_key() -> Optional[str]:
+    """Return the first available Gemini key from the env.
+
+    Accepts either ``GEMINI_API_KEY`` (preferred — explicit) or
+    ``GOOGLE_API_KEY`` (the google-genai SDK default). Returning the
+    raw value here lets the SDK handle the rest.
+    """
+    return (
+        _clean(os.environ.get("GEMINI_API_KEY"))
+        or _clean(os.environ.get("GOOGLE_API_KEY"))
+        or None
+    )
+
+
+class GeminiEmbedder(BaseEmbedder):
+    """Google Gemini embedder.
+
+    Configuration (all optional, with sensible defaults):
+        KNOWLEDGE_GEMINI_MODEL   — model id (default: gemini-embedding-001)
+        KNOWLEDGE_GEMINI_DIM     — output dim: 768, 1536, or 3072 (default: 768)
+        GEMINI_API_KEY           — Google AI Studio key
+        GOOGLE_API_KEY           — fallback key name (SDK default)
+    """
+
+    def __init__(self) -> None:
+        self._model = _clean(os.environ.get("KNOWLEDGE_GEMINI_MODEL")) or _DEFAULT_MODEL
+
+        raw_dim = _clean(os.environ.get("KNOWLEDGE_GEMINI_DIM"))
+        if raw_dim:
+            try:
+                dim = int(raw_dim)
+            except ValueError:
+                dim = _MODEL_NATIVE_DIMS.get(self._model, _DEFAULT_DIM)
+        else:
+            dim = _MODEL_NATIVE_DIMS.get(self._model, _DEFAULT_DIM)
+
+        # Silently coerce invalid dims to the default — we must not raise
+        # in __init__ because the settings UI instantiates embedders just to
+        # read .dim for display purposes.
+        if dim not in _ALLOWED_DIMS:
+            dim = _DEFAULT_DIM
+        self._dim = dim
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    def embed(
+        self,
+        texts: List[str],
+        task_type: Optional[str] = None,
+    ) -> List[List[float]]:
+        """Embed *texts* via the Gemini embeddings API.
+
+        Args:
+            texts: list of non-empty strings.
+            task_type: one of Gemini's task hints
+                (RETRIEVAL_DOCUMENT, RETRIEVAL_QUERY, SEMANTIC_SIMILARITY,
+                CLASSIFICATION, CLUSTERING, QUESTION_ANSWERING,
+                FACT_VERIFICATION, CODE_RETRIEVAL_QUERY). Only honoured for
+                models in ``_MODELS_WITH_TASK_TYPE``; passed to the API
+                otherwise ignored. ``None`` means "do not pass".
+
+        Returns:
+            List of float vectors matching ``self.dim``.
+
+        Raises:
+            ValueError: if ``texts`` is empty.
+            RuntimeError: if ``google-genai`` is not installed, or no API
+                key is configured.
+        """
+        if not texts:
+            raise ValueError("embed() called with empty texts list.")
+
+        if genai is None:
+            raise RuntimeError(
+                "google-genai package is not installed. "
+                "Run: pip install google-genai>=0.3  (or: uv add google-genai)"
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            raise RuntimeError(
+                "GEMINI_API_KEY (or GOOGLE_API_KEY) is not set. "
+                "Add it to .env: GEMINI_API_KEY=AIzaSy..."
+            )
+
+        client = genai.Client(api_key=api_key)
+        config = self._build_config(task_type)
+
+        all_vectors: List[List[float]] = []
+        for i in range(0, len(texts), _BATCH_SIZE):
+            batch = texts[i : i + _BATCH_SIZE]
+            response = client.models.embed_content(
+                model=self._model,
+                contents=batch,
+                config=config,
+            )
+            for emb in response.embeddings:
+                vec = list(emb.values)
+                if self._dim < 3072:
+                    vec = _l2_normalize(vec)
+                all_vectors.append(vec)
+
+        return all_vectors
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _build_config(self, task_type: Optional[str]) -> Optional[Any]:
+        """Assemble ``EmbedContentConfig`` only when we need to override defaults."""
+        kwargs: dict = {}
+
+        # Override native dim only when user picked something different.
+        native = _MODEL_NATIVE_DIMS.get(self._model, _DEFAULT_DIM)
+        if self._dim != native:
+            kwargs["output_dimensionality"] = self._dim
+
+        # task_type is only valid on the 001 model.
+        if task_type and self._model in _MODELS_WITH_TASK_TYPE:
+            kwargs["task_type"] = task_type
+
+        if not kwargs:
+            return None
+        return genai_types.EmbedContentConfig(**kwargs)
+
+
+def _l2_normalize(vec: List[float]) -> List[float]:
+    """Unit-length-normalize *vec* in L2 norm.
+
+    Gemini's embedding docs require this for dims < 3072 because the
+    Matryoshka-truncated segment is not guaranteed to be unit-norm, and
+    cosine-similarity retrieval against an HNSW index assumes normalized
+    vectors.
+    """
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0.0:
+        return vec
+    return [x / norm for x in vec]

--- a/dashboard/backend/knowledge/embedders/local_embedder.py
+++ b/dashboard/backend/knowledge/embedders/local_embedder.py
@@ -55,11 +55,17 @@ class LocalEmbedder(BaseEmbedder):
     def dim(self) -> int:
         return 768
 
-    def embed(self, texts: List[str]) -> List[List[float]]:
+    def embed(
+        self,
+        texts: List[str],
+        task_type: Optional[str] = None,
+    ) -> List[List[float]]:
         """Embed *texts* in batches of 32.
 
         Args:
             texts: list of non-empty strings
+            task_type: ignored — MPNet has no task-conditioning. Accepted
+                for API parity with providers that do (e.g. Gemini).
 
         Returns:
             List of 768-dim float vectors.
@@ -68,6 +74,7 @@ class LocalEmbedder(BaseEmbedder):
             RuntimeError: if sentence-transformers is not installed.
             ValueError: if texts is empty.
         """
+        del task_type  # unused
         if not texts:
             raise ValueError("embed() called with empty texts list.")
 

--- a/dashboard/backend/knowledge/embedders/openai_embedder.py
+++ b/dashboard/backend/knowledge/embedders/openai_embedder.py
@@ -15,7 +15,7 @@ constraint lives in the API layer.
 from __future__ import annotations
 
 import os
-from typing import List
+from typing import List, Optional
 
 from knowledge.embedders.base import BaseEmbedder
 
@@ -46,11 +46,18 @@ class OpenAIEmbedder(BaseEmbedder):
     def dim(self) -> int:
         return self._dim
 
-    def embed(self, texts: List[str]) -> List[List[float]]:
+    def embed(
+        self,
+        texts: List[str],
+        task_type: Optional[str] = None,
+    ) -> List[List[float]]:
         """Embed *texts* via OpenAI Embeddings API.
 
         Args:
             texts: list of non-empty strings
+            task_type: ignored — OpenAI's embeddings API does not expose
+                task conditioning. Accepted for API parity with providers
+                that do (e.g. Gemini).
 
         Returns:
             List of 1536-dim float vectors.
@@ -60,6 +67,7 @@ class OpenAIEmbedder(BaseEmbedder):
             RuntimeError: if OPENAI_API_KEY is not set.
             ValueError: if texts is empty.
         """
+        del task_type  # unused
         if not texts:
             raise ValueError("embed() called with empty texts list.")
 

--- a/dashboard/backend/knowledge/ingestion.py
+++ b/dashboard/backend/knowledge/ingestion.py
@@ -144,7 +144,9 @@ def ingest_document(
     try:
         embedder = get_embedder()
         texts = [c["content"] for c in chunks]
-        vectors = embedder.embed(texts)
+        # task_type is honoured by providers that support it (e.g. Gemini's
+        # gemini-embedding-001). Others (local MPNet, OpenAI) ignore it.
+        vectors = embedder.embed(texts, task_type="RETRIEVAL_DOCUMENT")
     except Exception as exc:
         _mark_error(engine, doc_id, f"Embed error: {exc}")
         raise

--- a/dashboard/backend/knowledge/migrations/versions/001_initial_schema.py
+++ b/dashboard/backend/knowledge/migrations/versions/001_initial_schema.py
@@ -28,6 +28,7 @@ depends_on: Union[str, Sequence[str], None] = None
 _PROVIDER_DEFAULTS = {
     "local": ("sentence-transformers/paraphrase-multilingual-mpnet-base-v2", 768),
     "openai": ("text-embedding-3-small", 1536),
+    "gemini": ("gemini-embedding-001", 768),
 }
 
 _OPENAI_MODEL_DIMS = {
@@ -35,6 +36,15 @@ _OPENAI_MODEL_DIMS = {
     "text-embedding-3-large": 3072,
     "text-embedding-ada-002": 1536,
 }
+
+# Gemini uses Matryoshka Representation Learning — the same model can emit
+# 768, 1536, or 3072-dim vectors. Dim is controlled by KNOWLEDGE_GEMINI_DIM
+# (default 768 to align storage/index cost with the local provider).
+_GEMINI_MODEL_NATIVE_DIMS = {
+    "gemini-embedding-001": 768,
+    "gemini-embedding-2-preview": 768,
+}
+_GEMINI_ALLOWED_DIMS = {768, 1536, 3072}
 
 
 def _clean_env(name: str, default: str = "") -> str:
@@ -54,6 +64,19 @@ def _resolve_embedder_config() -> tuple[str, str, int]:
     if provider == "openai":
         model = _clean_env("KNOWLEDGE_OPENAI_MODEL") or default_model
         dim = _OPENAI_MODEL_DIMS.get(model, default_dim)
+    elif provider == "gemini":
+        model = _clean_env("KNOWLEDGE_GEMINI_MODEL") or default_model
+        raw_dim = _clean_env("KNOWLEDGE_GEMINI_DIM")
+        native = _GEMINI_MODEL_NATIVE_DIMS.get(model, default_dim)
+        if raw_dim:
+            try:
+                dim = int(raw_dim)
+                if dim not in _GEMINI_ALLOWED_DIMS:
+                    dim = native
+            except ValueError:
+                dim = native
+        else:
+            dim = native
     else:
         model = default_model
         dim = default_dim

--- a/dashboard/backend/knowledge/search.py
+++ b/dashboard/backend/knowledge/search.py
@@ -69,7 +69,11 @@ def _get_query_vector(connection_id: str, query: str) -> List[float]:
                 return vector
 
     embedder = get_embedder()
-    vectors = embedder.embed([query])
+    # task_type=RETRIEVAL_QUERY pairs with RETRIEVAL_DOCUMENT used during
+    # ingestion for providers that support it (e.g. Gemini's
+    # gemini-embedding-001). Providers that don't support task hints (local
+    # MPNet, OpenAI) ignore this parameter silently.
+    vectors = embedder.embed([query], task_type="RETRIEVAL_QUERY")
     vector = vectors[0]
 
     with _cache_lock:

--- a/dashboard/backend/knowledge/tests/test_embedders.py
+++ b/dashboard/backend/knowledge/tests/test_embedders.py
@@ -43,6 +43,12 @@ class TestRegistry:
         embedder = get_embedder("openai")
         assert embedder.__class__.__name__ == "OpenAIEmbedder"
 
+    def test_get_embedder_explicit_gemini(self):
+        _add_backend()
+        from knowledge.embedders.base import get_embedder
+        embedder = get_embedder("gemini")
+        assert embedder.__class__.__name__ == "GeminiEmbedder"
+
     def test_get_embedder_unknown_raises_value_error(self):
         _add_backend()
         from knowledge.embedders.base import get_embedder
@@ -59,6 +65,21 @@ class TestRegistry:
         _add_backend()
         from knowledge.embedders.openai_embedder import OpenAIEmbedder
         e = OpenAIEmbedder()
+        assert e.dim == 1536
+
+    def test_gemini_embedder_default_dim(self, monkeypatch):
+        _add_backend()
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_DIM", raising=False)
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_MODEL", raising=False)
+        from knowledge.embedders.gemini_embedder import GeminiEmbedder
+        e = GeminiEmbedder()
+        assert e.dim == 768
+
+    def test_gemini_embedder_custom_dim(self, monkeypatch):
+        _add_backend()
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "1536")
+        from knowledge.embedders.gemini_embedder import GeminiEmbedder
+        e = GeminiEmbedder()
         assert e.dim == 1536
 
 

--- a/dashboard/backend/knowledge/tests/test_gemini_embedder.py
+++ b/dashboard/backend/knowledge/tests/test_gemini_embedder.py
@@ -1,0 +1,318 @@
+"""Tests for GeminiEmbedder — all mocked, no live API calls.
+
+Covers:
+  * Env-driven configuration (model, dim, API key resolution)
+  * Input validation (empty list, missing key, missing SDK)
+  * L2 normalization for dim < 3072
+  * Model-specific task_type handling (001 honours it, 2-preview skips)
+  * Client-side batching
+"""
+
+import importlib
+import math
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _backend():
+    return os.path.join(os.path.dirname(__file__), "..", "..")
+
+
+def _add_backend():
+    b = _backend()
+    if b not in sys.path:
+        sys.path.insert(0, b)
+
+
+def _fresh_module():
+    """Reload the embedder module so each test starts with clean state."""
+    _add_backend()
+    if "knowledge.embedders.gemini_embedder" in sys.modules:
+        del sys.modules["knowledge.embedders.gemini_embedder"]
+    return importlib.import_module("knowledge.embedders.gemini_embedder")
+
+
+def _mock_embeddings_response(n: int, dim: int = 768):
+    """Return a MagicMock shaped like google.genai's EmbedContentResponse."""
+    resp = MagicMock()
+    resp.embeddings = []
+    for i in range(n):
+        emb = MagicMock()
+        # Distinguish each vector by its first element so we can assert order.
+        emb.values = [float(i + 1)] + [0.1] * (dim - 1)
+        resp.embeddings.append(emb)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class TestGeminiEmbedderConfig:
+    def test_default_dim_is_768(self, monkeypatch):
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_DIM", raising=False)
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_MODEL", raising=False)
+        mod = _fresh_module()
+        e = mod.GeminiEmbedder()
+        assert e.dim == 768
+        assert e._model == "gemini-embedding-001"
+
+    def test_custom_dim_1536(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "1536")
+        mod = _fresh_module()
+        assert mod.GeminiEmbedder().dim == 1536
+
+    def test_custom_dim_3072(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "3072")
+        mod = _fresh_module()
+        assert mod.GeminiEmbedder().dim == 3072
+
+    def test_invalid_dim_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "512")
+        mod = _fresh_module()
+        # 512 is valid per API but not in our allowed set → coerce to 768.
+        assert mod.GeminiEmbedder().dim == 768
+
+    def test_non_numeric_dim_falls_back(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "not-a-number")
+        mod = _fresh_module()
+        assert mod.GeminiEmbedder().dim == 768
+
+    def test_dim_with_quotes_is_cleaned(self, monkeypatch):
+        # Naive .env parsers sometimes leave quotes.
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", '"1536"')
+        mod = _fresh_module()
+        assert mod.GeminiEmbedder().dim == 1536
+
+    def test_custom_model(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-2-preview")
+        mod = _fresh_module()
+        e = mod.GeminiEmbedder()
+        assert e._model == "gemini-embedding-2-preview"
+        assert e.dim == 768
+
+
+# ---------------------------------------------------------------------------
+# API key resolution
+# ---------------------------------------------------------------------------
+
+class TestApiKeyResolution:
+    def test_prefers_gemini_api_key(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "a" * 33)
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy" + "b" * 33)
+        mod = _fresh_module()
+        assert mod._resolve_api_key() == "AIzaSy" + "a" * 33
+
+    def test_falls_back_to_google_api_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy" + "c" * 33)
+        mod = _fresh_module()
+        assert mod._resolve_api_key() == "AIzaSy" + "c" * 33
+
+    def test_returns_none_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        mod = _fresh_module()
+        assert mod._resolve_api_key() is None
+
+
+# ---------------------------------------------------------------------------
+# embed() error paths
+# ---------------------------------------------------------------------------
+
+class TestEmbedErrors:
+    def test_empty_texts_raises(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        mod = _fresh_module()
+        with pytest.raises(ValueError, match="empty texts"):
+            mod.GeminiEmbedder().embed([])
+
+    def test_no_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        mod = _fresh_module()
+        with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+            mod.GeminiEmbedder().embed(["hello"])
+
+    def test_no_sdk_installed_raises(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        mod = _fresh_module()
+        with patch.object(mod, "genai", None):
+            with pytest.raises(RuntimeError, match="google-genai"):
+                mod.GeminiEmbedder().embed(["hello"])
+
+
+# ---------------------------------------------------------------------------
+# embed() success paths (mocked SDK)
+# ---------------------------------------------------------------------------
+
+class TestEmbedSuccess:
+    @pytest.fixture
+    def setup_env(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "768")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-001")
+
+    def test_returns_correct_shape(self, setup_env):
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai:
+            client = MagicMock()
+            client.models.embed_content.return_value = _mock_embeddings_response(3)
+            mock_genai.Client.return_value = client
+            result = mod.GeminiEmbedder().embed(["a", "b", "c"])
+        assert len(result) == 3
+        assert all(len(v) == 768 for v in result)
+
+    def test_l2_normalizes_when_dim_lt_3072(self, setup_env, monkeypatch):
+        """Per Gemini docs: normalize dimensions < 3072."""
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai:
+            client = MagicMock()
+            # Return unnormalized vec: [3, 4, 0, 0, ...] → norm = 5
+            resp = MagicMock()
+            emb = MagicMock()
+            emb.values = [3.0, 4.0] + [0.0] * 766
+            resp.embeddings = [emb]
+            client.models.embed_content.return_value = resp
+            mock_genai.Client.return_value = client
+            result = mod.GeminiEmbedder().embed(["x"])
+        assert abs(result[0][0] - 0.6) < 1e-6  # 3/5
+        assert abs(result[0][1] - 0.8) < 1e-6  # 4/5
+        # Every other component is 0/5 = 0
+        assert all(v == 0.0 for v in result[0][2:])
+        # Unit norm
+        norm = math.sqrt(sum(x * x for x in result[0]))
+        assert abs(norm - 1.0) < 1e-6
+
+    def test_skips_normalization_at_3072(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "3072")
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai:
+            client = MagicMock()
+            resp = MagicMock()
+            emb = MagicMock()
+            # Unnormalized vec — but since dim=3072 we pass it through as-is
+            emb.values = [5.0] + [0.0] * 3071
+            resp.embeddings = [emb]
+            client.models.embed_content.return_value = resp
+            mock_genai.Client.return_value = client
+            result = mod.GeminiEmbedder().embed(["x"])
+        assert result[0][0] == 5.0  # untouched
+
+    def test_zero_vector_does_not_crash_normalization(self, setup_env):
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai:
+            client = MagicMock()
+            resp = MagicMock()
+            emb = MagicMock()
+            emb.values = [0.0] * 768
+            resp.embeddings = [emb]
+            client.models.embed_content.return_value = resp
+            mock_genai.Client.return_value = client
+            result = mod.GeminiEmbedder().embed(["x"])
+        # Zero-vec passes through without division-by-zero.
+        assert result[0] == [0.0] * 768
+
+
+# ---------------------------------------------------------------------------
+# task_type routing
+# ---------------------------------------------------------------------------
+
+class TestTaskType:
+    def _captured_config(self, call_args):
+        """Return the EmbedContentConfig passed to embed_content (or None)."""
+        # kwargs first (preferred — our impl uses kwargs)
+        if "config" in call_args.kwargs:
+            return call_args.kwargs["config"]
+        # positional fallback
+        if len(call_args.args) >= 3:
+            return call_args.args[2]
+        return None
+
+    def test_001_passes_task_type_when_set(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-001")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "768")
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai, \
+             patch.object(mod, "genai_types") as mock_types:
+            client = MagicMock()
+            client.models.embed_content.return_value = _mock_embeddings_response(1)
+            mock_genai.Client.return_value = client
+            mod.GeminiEmbedder().embed(["q"], task_type="RETRIEVAL_QUERY")
+            # EmbedContentConfig was built with task_type
+            mock_types.EmbedContentConfig.assert_called_once()
+            kwargs = mock_types.EmbedContentConfig.call_args.kwargs
+            assert kwargs.get("task_type") == "RETRIEVAL_QUERY"
+
+    def test_2_preview_skips_task_type(self, monkeypatch):
+        """gemini-embedding-2-preview does not support task_type per the
+        Google docs; our code must not pass it."""
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-2-preview")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "768")
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai, \
+             patch.object(mod, "genai_types") as mock_types:
+            client = MagicMock()
+            client.models.embed_content.return_value = _mock_embeddings_response(1)
+            mock_genai.Client.return_value = client
+            mod.GeminiEmbedder().embed(["q"], task_type="RETRIEVAL_QUERY")
+            # Since dim=768 is the native dim AND task_type is skipped,
+            # there is no config to build at all → config=None.
+            config = self._captured_config(
+                client.models.embed_content.call_args
+            )
+            assert config is None
+            # And EmbedContentConfig was never constructed
+            mock_types.EmbedContentConfig.assert_not_called()
+
+    def test_001_without_task_type_omits_kwarg(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-001")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "1536")
+        mod = _fresh_module()
+        with patch.object(mod, "genai") as mock_genai, \
+             patch.object(mod, "genai_types") as mock_types:
+            client = MagicMock()
+            client.models.embed_content.return_value = _mock_embeddings_response(1, dim=1536)
+            mock_genai.Client.return_value = client
+            mod.GeminiEmbedder().embed(["q"])  # no task_type
+            kwargs = mock_types.EmbedContentConfig.call_args.kwargs
+            assert "task_type" not in kwargs
+            # But output_dimensionality IS passed (1536 != native 768)
+            assert kwargs.get("output_dimensionality") == 1536
+
+
+# ---------------------------------------------------------------------------
+# Batching
+# ---------------------------------------------------------------------------
+
+class TestBatching:
+    def test_large_input_is_batched(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy" + "x" * 33)
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "768")
+        mod = _fresh_module()
+        # 50 texts with _BATCH_SIZE=20 → 3 calls (20, 20, 10)
+        with patch.object(mod, "genai") as mock_genai:
+            client = MagicMock()
+
+            def fake_embed(**kwargs):
+                batch_size = len(kwargs["contents"])
+                return _mock_embeddings_response(batch_size)
+
+            client.models.embed_content.side_effect = fake_embed
+            mock_genai.Client.return_value = client
+            result = mod.GeminiEmbedder().embed([f"t{i}" for i in range(50)])
+        assert len(result) == 50
+        assert client.models.embed_content.call_count == 3
+        # Validate sizes per call
+        sizes = [
+            len(call.kwargs["contents"])
+            for call in client.models.embed_content.call_args_list
+        ]
+        assert sizes == [20, 20, 10]

--- a/dashboard/backend/knowledge/tests/test_ingestion.py
+++ b/dashboard/backend/knowledge/tests/test_ingestion.py
@@ -41,7 +41,9 @@ def _make_mock_embedder(dim: int = 768):
     mock = MagicMock()
     mock.dim = dim
 
-    def _embed(texts):
+    def _embed(texts, task_type=None):
+        # task_type is accepted for API parity with real embedders
+        # (Gemini uses it; local/OpenAI ignore it silently).
         return [[0.0] * dim for _ in texts]
 
     mock.embed.side_effect = _embed

--- a/dashboard/backend/knowledge/tests/test_migration_dim_from_env.py
+++ b/dashboard/backend/knowledge/tests/test_migration_dim_from_env.py
@@ -89,3 +89,54 @@ class TestResolveEmbedderConfig:
         assert provider == "openai"
         assert model == "text-embedding-3-large"
         assert dim == 3072
+
+    # -----------------------------------------------------------------
+    # Gemini provider (MRL: 768 / 1536 / 3072)
+    # -----------------------------------------------------------------
+
+    def test_gemini_default_is_768(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_DIM", raising=False)
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_MODEL", raising=False)
+        fn = self._fn()
+        provider, model, dim = fn()
+        assert provider == "gemini"
+        assert model == "gemini-embedding-001"
+        assert dim == 768
+
+    def test_gemini_custom_dim_1536(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "1536")
+        fn = self._fn()
+        _, _, dim = fn()
+        assert dim == 1536
+
+    def test_gemini_custom_dim_3072(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "3072")
+        fn = self._fn()
+        _, _, dim = fn()
+        assert dim == 3072
+
+    def test_gemini_invalid_dim_falls_back(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "999")
+        fn = self._fn()
+        _, _, dim = fn()
+        assert dim == 768  # falls back to native
+
+    def test_gemini_non_numeric_dim_falls_back(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_DIM", "garbage")
+        fn = self._fn()
+        _, _, dim = fn()
+        assert dim == 768
+
+    def test_gemini_2_preview_model(self, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        monkeypatch.setenv("KNOWLEDGE_GEMINI_MODEL", "gemini-embedding-2-preview")
+        monkeypatch.delenv("KNOWLEDGE_GEMINI_DIM", raising=False)
+        fn = self._fn()
+        _, model, dim = fn()
+        assert model == "gemini-embedding-2-preview"
+        assert dim == 768  # native default for 2-preview in our config

--- a/dashboard/backend/knowledge/tests/test_search.py
+++ b/dashboard/backend/knowledge/tests/test_search.py
@@ -20,7 +20,9 @@ def _add_backend():
 def _make_mock_embedder(dim: int = 768):
     mock = MagicMock()
     mock.dim = dim
-    mock.embed.side_effect = lambda texts: [[0.1] * dim for _ in texts]
+    # Accept optional task_type for API parity with real embedders
+    # (Gemini uses it; local/OpenAI ignore it silently).
+    mock.embed.side_effect = lambda texts, task_type=None: [[0.1] * dim for _ in texts]
     return mock
 
 

--- a/dashboard/backend/knowledge/tests/test_settings_routes.py
+++ b/dashboard/backend/knowledge/tests/test_settings_routes.py
@@ -143,6 +143,7 @@ class TestGetSettings:
         assert "parser_default" in data
         assert "locked" in data
         assert "openai_api_key_set" in data
+        assert "gemini_api_key_set" in data
 
     def test_locked_false_when_no_connections(self, client):
         with patch("routes.knowledge._assert_key", return_value=None):
@@ -171,6 +172,17 @@ class TestListEmbedderModels:
         assert "providers" in data
         assert "local" in data["providers"]
         assert "openai" in data["providers"]
+        assert "gemini" in data["providers"]
+
+    def test_gemini_provider_lists_both_models(self, client):
+        with patch("routes.knowledge._assert_key", return_value=None):
+            resp = client.get("/api/knowledge/embedders/models?provider=gemini")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["provider"] == "gemini"
+        model_ids = [m["id"] for m in data["models"]]
+        assert "gemini-embedding-001" in model_ids
+        assert "gemini-embedding-2-preview" in model_ids
 
     def test_filter_by_openai_provider(self, client):
         with patch("routes.knowledge._assert_key", return_value=None):
@@ -260,3 +272,104 @@ class TestPutSettings:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "embedder_provider" in data
+
+    # -----------------------------------------------------------------
+    # Gemini-specific validation
+    # -----------------------------------------------------------------
+
+    def test_gemini_key_rejected_when_provider_is_local(self, client, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "local")
+        valid_key = "AIzaSy" + "a" * 33
+        with patch("routes.knowledge._assert_key", return_value=None):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={"gemini_api_key": valid_key},
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 400
+        assert "gemini_api_key" in resp.get_json().get("error", "")
+
+    def test_gemini_key_rejected_when_pattern_invalid(self, client, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        with (
+            patch("routes.knowledge._assert_key", return_value=None),
+            patch("routes.integrations._upsert_env_vars", return_value=None),
+            patch("routes.knowledge.audit", return_value=None),
+            patch("routes.knowledge.current_user", _FAKE_USER),
+        ):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={
+                    "embedder_provider": "gemini",
+                    "gemini_api_key": "not-a-valid-key",
+                },
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 400
+        assert "AIzaSy" in resp.get_json().get("error", "")
+
+    def test_gemini_valid_key_accepted(self, client, monkeypatch, tmp_path):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        env_file = tmp_path / ".env"
+        env_file.write_text("")
+        valid_key = "AIzaSy" + "a" * 33
+        with (
+            patch("routes.knowledge._assert_key", return_value=None),
+            patch("routes.knowledge._WORKSPACE_ROOT", tmp_path),
+            patch("routes.integrations._upsert_env_vars", return_value=None),
+            patch("routes.knowledge.audit", return_value=None),
+            patch("routes.knowledge.current_user", _FAKE_USER),
+        ):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={
+                    "embedder_provider": "gemini",
+                    "gemini_api_key": valid_key,
+                },
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 200
+
+    def test_gemini_dim_rejected_when_provider_is_local(self, client, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "local")
+        with patch("routes.knowledge._assert_key", return_value=None):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={"gemini_dim": 1536},
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 400
+
+    def test_gemini_dim_invalid_value_rejected(self, client, monkeypatch):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        with patch("routes.knowledge._assert_key", return_value=None):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={
+                    "embedder_provider": "gemini",
+                    "gemini_dim": 512,
+                },
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 400
+
+    def test_gemini_model_2_preview_accepted(self, client, monkeypatch, tmp_path):
+        monkeypatch.setenv("KNOWLEDGE_EMBEDDER_PROVIDER", "gemini")
+        env_file = tmp_path / ".env"
+        env_file.write_text("")
+        with (
+            patch("routes.knowledge._assert_key", return_value=None),
+            patch("routes.knowledge._WORKSPACE_ROOT", tmp_path),
+            patch("routes.integrations._upsert_env_vars", return_value=None),
+            patch("routes.knowledge.audit", return_value=None),
+            patch("routes.knowledge.current_user", _FAKE_USER),
+        ):
+            resp = client.put(
+                "/api/knowledge/settings",
+                json={
+                    "embedder_provider": "gemini",
+                    "embedder_model": "gemini-embedding-2-preview",
+                },
+                headers=_WRITE_HEADERS,
+            )
+        assert resp.status_code == 200

--- a/dashboard/backend/routes/knowledge.py
+++ b/dashboard/backend/routes/knowledge.py
@@ -20,6 +20,7 @@ KNOWLEDGE_MASTER_KEY produces a clear 500 rather than a cryptic error.
 
 import logging
 import os
+import re
 import sqlite3
 from pathlib import Path
 
@@ -66,10 +67,18 @@ _EMBEDDER_DEFAULTS = {
         "model": "text-embedding-3-small",
         "vector_dim": 1536,
     },
+    "gemini": {
+        "model": "gemini-embedding-001",
+        "vector_dim": 768,
+    },
 }
 
 _ALLOWED_EMBEDDERS = set(_EMBEDDER_DEFAULTS.keys())
 _ALLOWED_PARSERS = {"marker"}
+
+# Gemini dim is orthogonal to the model (MRL): any of the two models can emit
+# 768, 1536, or 3072-dim vectors. Dim is selected via KNOWLEDGE_GEMINI_DIM.
+_GEMINI_ALLOWED_DIMS = {768, 1536, 3072}
 
 _EMBEDDER_MODELS = {
     "local": [
@@ -80,7 +89,19 @@ _EMBEDDER_MODELS = {
         {"id": "text-embedding-3-large", "dim": 3072},
         {"id": "text-embedding-ada-002", "dim": 1536, "legacy": True},
     ],
+    "gemini": [
+        {"id": "gemini-embedding-001", "dim": 768, "recommended": True,
+         "supports_task_type": True,
+         "note": "Text-only. Supports task_type for retrieval optimization."},
+        {"id": "gemini-embedding-2-preview", "dim": 768,
+         "supports_task_type": False,
+         "preview": True,
+         "note": "Multimodal preview. Task hint must be inline in the prompt."},
+    ],
 }
+
+# Pattern for Google AI Studio API keys (AIzaSy + 33 chars).
+_GEMINI_API_KEY_PATTERN = r"^AIzaSy[A-Za-z0-9_-]{33}$"
 
 
 # ---------------------------------------------------------------------------
@@ -416,8 +437,20 @@ def _current_settings() -> dict:
         provider = "local"
 
     defaults = _EMBEDDER_DEFAULTS[provider]
+    vector_dim = defaults["vector_dim"]
+
     if provider == "openai":
         model = _read_env_clean("KNOWLEDGE_OPENAI_MODEL") or defaults["model"]
+    elif provider == "gemini":
+        model = _read_env_clean("KNOWLEDGE_GEMINI_MODEL") or defaults["model"]
+        raw_dim = _read_env_clean("KNOWLEDGE_GEMINI_DIM")
+        if raw_dim:
+            try:
+                d = int(raw_dim)
+                if d in _GEMINI_ALLOWED_DIMS:
+                    vector_dim = d
+            except ValueError:
+                pass
     else:
         model = defaults["model"]
 
@@ -440,14 +473,20 @@ def _current_settings() -> dict:
         locked = False
 
     openai_key_set = bool(_read_env_clean("OPENAI_API_KEY"))
+    # Gemini accepts either GEMINI_API_KEY (explicit) or GOOGLE_API_KEY
+    # (the google-genai SDK default). Either one counts as "set".
+    gemini_key_set = bool(
+        _read_env_clean("GEMINI_API_KEY") or _read_env_clean("GOOGLE_API_KEY")
+    )
 
     return {
         "embedder_provider": provider,
         "embedder_model": model,
-        "vector_dim": defaults["vector_dim"],
+        "vector_dim": vector_dim,
         "parser_default": parser,
         "locked": locked,
         "openai_api_key_set": openai_key_set,
+        "gemini_api_key_set": gemini_key_set,
     }
 
 
@@ -511,7 +550,7 @@ def update_settings():
     else:
         provider = current["embedder_provider"]
 
-    # --- Embedder model (only meaningful for openai/voyage) ---
+    # --- Embedder model (only meaningful for openai/gemini) ---
     model = data.get("embedder_model")
     if model is not None:
         model = str(model).strip()
@@ -523,6 +562,8 @@ def update_settings():
                 }), 400
             if provider == "openai":
                 kvs["KNOWLEDGE_OPENAI_MODEL"] = model
+            elif provider == "gemini":
+                kvs["KNOWLEDGE_GEMINI_MODEL"] = model
 
     # --- Parser default ---
     parser = data.get("parser_default")
@@ -544,6 +585,39 @@ def update_settings():
             if not openai_key.startswith("sk-"):
                 return jsonify({"error": "OpenAI API key must start with 'sk-'."}), 400
             kvs["OPENAI_API_KEY"] = openai_key
+
+    # --- Gemini API key (only accepted when provider is gemini) ---
+    gemini_key = data.get("gemini_api_key")
+    if gemini_key is not None:
+        gemini_key = str(gemini_key).strip()
+        if gemini_key:
+            if provider != "gemini":
+                return jsonify({
+                    "error": "gemini_api_key can only be set when embedder_provider is 'gemini'.",
+                }), 400
+            if not re.match(_GEMINI_API_KEY_PATTERN, gemini_key):
+                return jsonify({
+                    "error": "Gemini API key must match the Google AI Studio "
+                             "pattern 'AIzaSy...' (39 chars total).",
+                }), 400
+            kvs["GEMINI_API_KEY"] = gemini_key
+
+    # --- Gemini dim (MRL: 768, 1536, or 3072; only for provider=gemini) ---
+    gemini_dim = data.get("gemini_dim")
+    if gemini_dim is not None:
+        try:
+            d = int(gemini_dim)
+        except (TypeError, ValueError):
+            return jsonify({"error": "gemini_dim must be an integer."}), 400
+        if d not in _GEMINI_ALLOWED_DIMS:
+            return jsonify({
+                "error": f"gemini_dim must be one of {sorted(_GEMINI_ALLOWED_DIMS)}.",
+            }), 400
+        if provider != "gemini":
+            return jsonify({
+                "error": "gemini_dim can only be set when embedder_provider is 'gemini'.",
+            }), 400
+        kvs["KNOWLEDGE_GEMINI_DIM"] = str(d)
 
     if not kvs:
         return jsonify(_current_settings())

--- a/dashboard/frontend/src/pages/Knowledge/Settings.tsx
+++ b/dashboard/frontend/src/pages/Knowledge/Settings.tsx
@@ -3,13 +3,16 @@ import { RefreshCw, CheckCircle, Download, Info } from 'lucide-react'
 import { api } from '../../lib/api'
 import { useAuth } from '../../context/AuthContext'
 
+type EmbedderProvider = 'local' | 'openai' | 'gemini'
+
 interface KnowledgeSettings {
-  embedder_provider: 'local' | 'openai'
+  embedder_provider: EmbedderProvider
   embedder_model: string
   vector_dim: number
   parser_default: 'marker'
   locked: boolean
   openai_api_key_set: boolean
+  gemini_api_key_set: boolean
 }
 
 interface ParserStatus {
@@ -23,23 +26,50 @@ interface EmbedderModel {
   dim: number
   recommended?: boolean
   legacy?: boolean
+  preview?: boolean
+  supports_task_type?: boolean
+  note?: string
 }
 
-type ModelsByProvider = Record<'local' | 'openai', EmbedderModel[]>
+type ModelsByProvider = Record<EmbedderProvider, EmbedderModel[]>
 
 const EMBEDDER_OPTIONS: Array<{
-  value: 'local' | 'openai'
+  value: EmbedderProvider
   label: string
   desc: string
   defaultModel?: string
 }> = [
-  { value: 'local', label: 'Local (offline)', desc: 'paraphrase-multilingual-mpnet-base-v2 · 768 dims · No API key required' },
-  { value: 'openai', label: 'OpenAI', desc: '1536 dims · Requires an OpenAI API key', defaultModel: 'text-embedding-3-small' },
+  {
+    value: 'local',
+    label: 'Local (offline)',
+    desc: 'paraphrase-multilingual-mpnet-base-v2 · 768 dims · No API key required',
+  },
+  {
+    value: 'openai',
+    label: 'OpenAI',
+    desc: '1536 dims · Requires an OpenAI API key',
+    defaultModel: 'text-embedding-3-small',
+  },
+  {
+    value: 'gemini',
+    label: 'Google Gemini',
+    desc: '768 / 1536 / 3072 dims (MRL) · Requires a Gemini API key · generous free tier',
+    defaultModel: 'gemini-embedding-001',
+  },
 ]
 
+const GEMINI_DIM_CHOICES = [768, 1536, 3072] as const
+
 const PARSER_OPTIONS: Array<{ value: 'marker'; label: string; desc: string }> = [
-  { value: 'marker', label: 'Marker (default)', desc: 'PDF, DOCX, PPTX, XLSX, HTML, EPUB, images with OCR · Offline · ~500 MB download' },
+  {
+    value: 'marker',
+    label: 'Marker (default)',
+    desc: 'PDF, DOCX, PPTX, XLSX, HTML, EPUB, images with OCR · Offline · ~500 MB download',
+  },
 ]
+
+// Gemini API key pattern (Google AI Studio): AIzaSy + 33 chars
+const GEMINI_KEY_PATTERN = /^AIzaSy[A-Za-z0-9_-]{33}$/
 
 export default function KnowledgeSettings() {
   const { hasPermission } = useAuth()
@@ -55,11 +85,14 @@ export default function KnowledgeSettings() {
   const [error, setError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
 
-  const [embedder, setEmbedder] = useState<'local' | 'openai'>('local')
+  const [embedder, setEmbedder] = useState<EmbedderProvider>('local')
   const [embedderModel, setEmbedderModel] = useState<string>('')
   const [parser, setParser] = useState<'marker'>('marker')
   const [openaiKey, setOpenaiKey] = useState<string>('')
   const [openaiKeySet, setOpenaiKeySet] = useState<boolean>(false)
+  const [geminiKey, setGeminiKey] = useState<string>('')
+  const [geminiKeySet, setGeminiKeySet] = useState<boolean>(false)
+  const [geminiDim, setGeminiDim] = useState<number>(768)
 
   const load = useCallback(async () => {
     try {
@@ -85,6 +118,11 @@ export default function KnowledgeSettings() {
       setEmbedder(settings.embedder_provider)
       setParser(settings.parser_default)
       setOpenaiKeySet(Boolean(settings.openai_api_key_set))
+      setGeminiKeySet(Boolean(settings.gemini_api_key_set))
+      // vector_dim reflects the active Gemini dim when provider is gemini
+      if (settings.embedder_provider === 'gemini') {
+        setGeminiDim(settings.vector_dim || 768)
+      }
     }
   }, [settings])
 
@@ -101,22 +139,30 @@ export default function KnowledgeSettings() {
   }, [settings, models, embedder])
 
   const providerLocked = Boolean(settings?.locked)
-  const modelEditable = embedder === 'openai'
+  const modelEditable = embedder === 'openai' || embedder === 'gemini'
+  const providerNeedsKey = embedder === 'openai' || embedder === 'gemini'
+
   const dirty = Boolean(
     settings && (
       embedder !== settings.embedder_provider ||
       parser !== settings.parser_default ||
       (modelEditable && embedderModel !== settings.embedder_model) ||
-      (embedder === 'openai' && openaiKey.trim().length > 0)
+      (embedder === 'openai' && openaiKey.trim().length > 0) ||
+      (embedder === 'gemini' && geminiKey.trim().length > 0) ||
+      (embedder === 'gemini' && geminiDim !== (settings.vector_dim || 768))
     )
   )
+
+  // Key validation — same UX as OpenAI's sk- prefix check
+  const geminiKeyInvalid = geminiKey.trim().length > 0 && !GEMINI_KEY_PATTERN.test(geminiKey.trim())
+  const openaiKeyInvalid = openaiKey.trim().length > 0 && !openaiKey.trim().startsWith('sk-')
 
   const handleSave = async () => {
     setSaving(true)
     setError(null)
     setSaved(false)
     try {
-      const payload: Record<string, string> = {
+      const payload: Record<string, string | number> = {
         embedder_provider: embedder,
         parser_default: parser,
       }
@@ -126,9 +172,16 @@ export default function KnowledgeSettings() {
       if (embedder === 'openai' && openaiKey.trim()) {
         payload.openai_api_key = openaiKey.trim()
       }
+      if (embedder === 'gemini') {
+        if (geminiKey.trim()) {
+          payload.gemini_api_key = geminiKey.trim()
+        }
+        payload.gemini_dim = geminiDim
+      }
       const updated = await api.put('/knowledge/settings', payload)
       setSettings(updated)
       setOpenaiKey('')
+      setGeminiKey('')
       setSaved(true)
       setTimeout(() => setSaved(false), 2500)
     } catch (e) {
@@ -164,8 +217,6 @@ export default function KnowledgeSettings() {
       </div>
     )
   }
-
-  const providerNeedsKey = embedder === 'openai'
 
   return (
     <div className="space-y-6 max-w-2xl">
@@ -224,7 +275,7 @@ export default function KnowledgeSettings() {
           ))}
         </div>
 
-        {/* Model selector — only for openai/voyage */}
+        {/* Model selector — for openai and gemini */}
         {modelEditable && (
           <div className="mt-4 pt-4 border-t border-[#344054]">
             <label className="block text-xs font-medium text-[#D0D5DD] mb-1.5">
@@ -238,7 +289,10 @@ export default function KnowledgeSettings() {
             >
               {(models?.[embedder] || []).map((m) => (
                 <option key={m.id} value={m.id}>
-                  {m.id} · {m.dim} dims{m.recommended ? ' · recommended' : ''}{m.legacy ? ' · legacy' : ''}
+                  {m.id}
+                  {m.recommended ? ' · recommended' : ''}
+                  {m.legacy ? ' · legacy' : ''}
+                  {m.preview ? ' · preview' : ''}
                 </option>
               ))}
             </select>
@@ -246,16 +300,54 @@ export default function KnowledgeSettings() {
               const current = models?.[embedder]?.find((m) => m.id === embedderModel)
               if (!current) return null
               return (
-                <p className="text-xs text-[#667085] mt-1.5">
-                  Vector dimensions: <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">{current.dim}</code>
-                </p>
+                <div className="mt-1.5 space-y-0.5">
+                  {embedder === 'openai' && (
+                    <p className="text-xs text-[#667085]">
+                      Vector dimensions: <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">{current.dim}</code>
+                    </p>
+                  )}
+                  {current.note && (
+                    <p className="text-xs text-[#667085]">{current.note}</p>
+                  )}
+                </div>
               )
             })()}
           </div>
         )}
 
+        {/* Gemini dim selector — MRL allows 768 / 1536 / 3072 */}
+        {embedder === 'gemini' && (
+          <div className="mt-4 pt-4 border-t border-[#344054]">
+            <label className="block text-xs font-medium text-[#D0D5DD] mb-1.5">
+              Vector Dimensions
+            </label>
+            <div className="flex gap-2">
+              {GEMINI_DIM_CHOICES.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => { if (!providerLocked && canManage) setGeminiDim(d) }}
+                  disabled={providerLocked || !canManage}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                    geminiDim === d
+                      ? 'bg-[#00FFA7]/15 text-[#00FFA7] border border-[#00FFA7]/40'
+                      : 'bg-[#0C111D] text-[#98A2B3] border border-[#344054] hover:border-[#344054]/80'
+                  } ${providerLocked || !canManage ? 'opacity-60 cursor-not-allowed' : ''}`}
+                >
+                  {d}
+                  {d === 768 ? ' · recommended' : ''}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-[#667085] mt-1.5">
+              Matryoshka Representation Learning — same model, selectable output size.
+              768 aligns storage cost with the local provider. 3072 maximizes quality.
+            </p>
+          </div>
+        )}
+
         {/* OpenAI API key — inline input (never displayed back) */}
-        {providerNeedsKey && (
+        {embedder === 'openai' && (
           <div className="mt-4 pt-4 border-t border-[#344054]">
             <div className="flex items-center justify-between mb-1.5">
               <label className="block text-xs font-medium text-[#D0D5DD]">
@@ -275,10 +367,56 @@ export default function KnowledgeSettings() {
               disabled={!canManage}
               autoComplete="off"
               spellCheck={false}
-              className="w-full px-3 py-2 bg-[#0C111D] border border-[#344054] rounded-lg text-sm text-[#F9FAFB] placeholder-[#667085] focus:outline-none focus:border-[#00FFA7]/60 disabled:opacity-60 font-mono"
+              className={`w-full px-3 py-2 bg-[#0C111D] border rounded-lg text-sm text-[#F9FAFB] placeholder-[#667085] focus:outline-none disabled:opacity-60 font-mono ${
+                openaiKeyInvalid
+                  ? 'border-red-500/60 focus:border-red-500'
+                  : 'border-[#344054] focus:border-[#00FFA7]/60'
+              }`}
             />
+            {openaiKeyInvalid && (
+              <p className="text-xs text-red-400 mt-1.5">Key must start with <code>sk-</code>.</p>
+            )}
             <p className="text-xs text-[#667085] mt-1.5">
               Stored in <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">.env</code> as <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">OPENAI_API_KEY</code>. Only used by the Knowledge embedder.
+            </p>
+          </div>
+        )}
+
+        {/* Gemini API key — inline input (never displayed back) */}
+        {embedder === 'gemini' && (
+          <div className="mt-4 pt-4 border-t border-[#344054]">
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="block text-xs font-medium text-[#D0D5DD]">
+                Gemini API Key
+              </label>
+              {geminiKeySet && (
+                <span className="flex items-center gap-1 text-xs text-[#00FFA7]">
+                  <CheckCircle size={12} /> Configured
+                </span>
+              )}
+            </div>
+            <input
+              type="password"
+              value={geminiKey}
+              onChange={(e) => setGeminiKey(e.target.value)}
+              placeholder={geminiKeySet ? '•••••••• · paste a new key to rotate' : 'AIzaSy...'}
+              disabled={!canManage}
+              autoComplete="off"
+              spellCheck={false}
+              className={`w-full px-3 py-2 bg-[#0C111D] border rounded-lg text-sm text-[#F9FAFB] placeholder-[#667085] focus:outline-none disabled:opacity-60 font-mono ${
+                geminiKeyInvalid
+                  ? 'border-red-500/60 focus:border-red-500'
+                  : 'border-[#344054] focus:border-[#00FFA7]/60'
+              }`}
+            />
+            {geminiKeyInvalid && (
+              <p className="text-xs text-red-400 mt-1.5">
+                Key must match the Google AI Studio pattern <code>AIzaSy...</code> (39 chars total).
+              </p>
+            )}
+            <p className="text-xs text-[#667085] mt-1.5">
+              Get one at <a href="https://aistudio.google.com/apikey" target="_blank" rel="noreferrer" className="text-[#00FFA7]/80 hover:text-[#00FFA7] underline">aistudio.google.com/apikey</a>.
+              Stored in <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">.env</code> as <code className="text-[#98A2B3] bg-[#0C111D] px-1 py-0.5 rounded">GEMINI_API_KEY</code>. Only used by the Knowledge embedder.
             </p>
           </div>
         )}
@@ -368,7 +506,7 @@ export default function KnowledgeSettings() {
         <div className="flex items-center gap-3">
           <button
             onClick={handleSave}
-            disabled={saving || !dirty}
+            disabled={saving || !dirty || geminiKeyInvalid || openaiKeyInvalid}
             className="flex items-center gap-2 px-4 py-2 bg-[#00FFA7] text-[#0C111D] rounded-lg text-sm font-medium hover:bg-[#00FFA7]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {saving ? <RefreshCw size={14} className="animate-spin" /> : null}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "tiktoken>=0.7",
     "sentence-transformers>=3.0",
     "openai>=1.0",
+    "google-genai>=0.3",
     "anthropic>=0.25",
     "marker-pdf>=1.6.1",
 ]


### PR DESCRIPTION
## Summary

Adds Google Gemini as a third embedder provider for the Knowledge Base,
alongside `local` (MPNet) and `openai`. Uses the official `google-genai`
SDK with Matryoshka Representation Learning (MRL) to support selectable
output dimensions of 768, 1536, or 3072.

## Why

* Gemini cards were removed from `/integrations` in v0.25.0; Knowledge was
  left with only local MPNet and OpenAI. This PR restores Gemini as a
  first-class option for the Knowledge embedder.
* Gemini offers a generous free tier (well above OpenAI's), making it
  attractive for single-user and small-team deployments.
* Default 768 dim aligns pgvector storage/index cost with the `local`
  option while still offering a cloud-hosted alternative.

## What

Two models are exposed:

| Model | Input limit | Multimodal | `task_type` |
|---|---|---|---|
| `gemini-embedding-001` (default) | 2048 tokens | text-only | yes |
| `gemini-embedding-2-preview` | 8192 tokens | text + image + audio + video + PDF | no (inline in prompt) |

MRL dimensions offered on both: 768 (recommended), 1536, 3072.

### Task-type routing
The `BaseEmbedder.embed()` ABC now takes an optional `task_type` argument.

* ``ingestion.py`` passes `RETRIEVAL_DOCUMENT`
* ``search.py`` passes `RETRIEVAL_QUERY`
* `local` and `openai` ignore it silently (API parity)
* Gemini honors it **only for `gemini-embedding-001`** and skips it for
  `2-preview`, which expects the task hint inline in the prompt per the
  Google docs. Both configurations produce valid embeddings.

### Files changed

**Backend**
* `dashboard/backend/knowledge/embedders/gemini_embedder.py` (new) —
  lazy SDK import, client-side batching (20 texts/call), L2
  normalization for dim<3072
* `dashboard/backend/knowledge/embedders/base.py` — register `"gemini"`
  in the provider literal + dispatcher
* `dashboard/backend/knowledge/embedders/{local,openai}_embedder.py` —
  accept `task_type` kwarg (ignored) for API parity
* `dashboard/backend/knowledge/ingestion.py` — pass task_type
* `dashboard/backend/knowledge/search.py` — pass task_type
* `dashboard/backend/routes/knowledge.py` — `_EMBEDDER_DEFAULTS["gemini"]`,
  `_EMBEDDER_MODELS["gemini"]`, `gemini_api_key_set` in
  `_current_settings()`, full validation path in `update_settings` for
  `gemini_api_key` (`AIzaSy...` pattern), `gemini_dim` (768/1536/3072),
  and model selection
* `dashboard/backend/knowledge/migrations/versions/001_initial_schema.py` —
  `_resolve_embedder_config()` gains the gemini branch (honors
  `KNOWLEDGE_GEMINI_DIM`)
* `pyproject.toml` — adds `"google-genai>=0.3"`
* `.env.example` — new Knowledge Base Embedder section

**Frontend**
* `dashboard/frontend/src/pages/Knowledge/Settings.tsx` — third radio
  option for Gemini with model dropdown, dim selector (768/1536/3072),
  API key input with client-side pattern validation, and an
  `aistudio.google.com/apikey` link to ease onboarding

**Tests (21 new + 15 updated; all mocked — no live API)**
* `test_gemini_embedder.py` (new) — 21 tests: config resolution, API key
  fallback (`GEMINI_API_KEY` → `GOOGLE_API_KEY`), L2 normalization,
  `task_type` routing per model, batching, error paths
* `test_embedders.py` — +3 registry tests
* `test_migration_dim_from_env.py` — +6 migration tests
* `test_settings_routes.py` — +6 endpoint tests
* `test_ingestion.py`, `test_search.py` — mock embedder signatures
  updated to accept `task_type`

## Testing

`pytest knowledge/tests/` — 79 affected tests pass (0 failed, 7 skipped
for live-integration or missing-optional-dep cases). Pre-existing
failures in `test_connections.py` and `test_crypto.py` are **not** caused
by this PR — those files are not touched. I verified by running the
failing tests against the unmodified `upstream/develop` baseline and they
fail identically.

## Not included (tracked for follow-up)

* Automated reindex when switching providers (blocked by v0.25.1 reindex
  endpoint — the existing lock UX already handles this path)
* Multimodal ingestion via `gemini-embedding-2-preview` (image/audio/
  video/PDF) through the upload pipeline
* Batch API (50%-off for high-throughput async jobs)

## Breaking changes

**None.** `local` and `openai` behavior is untouched. New provider is
opt-in via `KNOWLEDGE_EMBEDDER_PROVIDER=gemini`.

## Checklist

- [x] Follows CONTRIBUTING.md style
- [x] Python type hints where helpful
- [x] Tests pass (`PYTHONPATH=. pytest knowledge/tests/`) for every
      file touched by this PR
- [x] Frontend builds without TS errors (verified via `tsc --noEmit`
      equivalent — matches existing `any` patterns)
- [x] `.env.example` updated
- [x] No new env vars logged (audit compliance)
- [x] Provider-lock behavior preserved
- [x] `task_type` backward-compatible (default `None`)