### PR TITLE
feat(setup): auto-generate KNOWLEDGE_MASTER_KEY during setup and Docker first boot

### DIFF
--- a/dashboard/backend/knowledge/cli.py
+++ b/dashboard/backend/knowledge/cli.py
@@ -2,10 +2,15 @@
 
 Usage:
     evonexus init-key      # Generate KNOWLEDGE_MASTER_KEY and append to .env
+
+Also exports :func:`ensure_master_key` so that higher-level installers
+(setup.py, entrypoint.sh) can invoke the same idempotent generator
+without going through the CLI surface.
 """
 
 import sys
 from pathlib import Path
+from typing import Tuple
 
 
 def _find_env_file() -> Path:
@@ -56,27 +61,62 @@ def _append_to_env(env_path: Path, key: str, value: str, comment: str = "") -> N
         pass  # Windows or permissions issue — best-effort
 
 
-def cmd_init_key(args: list[str]) -> int:
-    """Generate and persist KNOWLEDGE_MASTER_KEY."""
-    from cryptography.fernet import Fernet
+_MASTER_KEY_NAME = "KNOWLEDGE_MASTER_KEY"
+_MASTER_KEY_COMMENT = (
+    "# Knowledge encryption key — DO NOT delete, DO NOT commit.\n"
+    "# Losing this key = losing access to ALL configured connections."
+)
 
-    env_path = _find_env_file()
-    current = _read_env_var(env_path, "KNOWLEDGE_MASTER_KEY")
+
+def ensure_master_key(env_path: Path) -> Tuple[bool, str]:
+    """Ensure *env_path* contains a valid ``KNOWLEDGE_MASTER_KEY``.
+
+    Idempotent. Generates a Fernet key only when one is not already set.
+
+    Args:
+        env_path: absolute path to the ``.env`` file. Parent is created if
+            missing. If the file itself does not exist, it is created.
+
+    Returns:
+        ``(was_generated, key_value)`` — ``was_generated`` is ``True`` when
+        a new key was written on this call, ``False`` when an existing one
+        was found. ``key_value`` is the active key in either case (useful
+        for logging truncated previews).
+
+    Raises:
+        RuntimeError: if the ``cryptography`` package is not installed.
+    """
+    try:
+        from cryptography.fernet import Fernet
+    except ImportError as exc:
+        raise RuntimeError(
+            "cryptography package is not installed. "
+            "Run: pip install cryptography  (or: uv sync)"
+        ) from exc
+
+    current = _read_env_var(env_path, _MASTER_KEY_NAME)
     if current:
+        return False, current
+
+    key = Fernet.generate_key().decode()
+    _append_to_env(env_path, _MASTER_KEY_NAME, key, comment=_MASTER_KEY_COMMENT)
+    return True, key
+
+
+def cmd_init_key(args: list[str]) -> int:
+    """Generate and persist KNOWLEDGE_MASTER_KEY (CLI wrapper).
+
+    Thin wrapper over :func:`ensure_master_key` that prints user-facing
+    output. Exit code is always 0 — both "generated" and "already present"
+    are success cases.
+    """
+    env_path = _find_env_file()
+    was_generated, _key = ensure_master_key(env_path)
+    if not was_generated:
         print("KNOWLEDGE_MASTER_KEY is already set. No-op.")
         print(f"  env file: {env_path}")
         return 0
 
-    key = Fernet.generate_key().decode()
-    _append_to_env(
-        env_path,
-        "KNOWLEDGE_MASTER_KEY",
-        key,
-        comment=(
-            "# Knowledge encryption key — DO NOT delete, DO NOT commit.\n"
-            "# Losing this key = losing access to ALL configured connections."
-        ),
-    )
     print(f"KNOWLEDGE_MASTER_KEY generated and written to: {env_path}")
     print(
         "WARNING: Back up your .env file. "

--- a/dashboard/backend/knowledge/tests/test_cli.py
+++ b/dashboard/backend/knowledge/tests/test_cli.py
@@ -1,0 +1,194 @@
+"""Tests for knowledge.cli — specifically ensure_master_key().
+
+Covers:
+  * Generates a fresh key when KNOWLEDGE_MASTER_KEY is absent.
+  * No-op when KNOWLEDGE_MASTER_KEY already exists.
+  * Creates the .env file when missing.
+  * Preserves existing .env content (other keys stay untouched).
+  * Idempotency (second call is a no-op).
+  * Generated key is a valid Fernet token (44 chars, urlsafe base64).
+  * File permissions set to 0o600 where the OS supports it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _add_backend():
+    b = os.path.join(os.path.dirname(__file__), "..", "..")
+    if b not in sys.path:
+        sys.path.insert(0, b)
+
+
+def _is_valid_fernet_key(key: str) -> bool:
+    """A Fernet key round-trips through Fernet() without raising."""
+    from cryptography.fernet import Fernet
+    try:
+        Fernet(key.encode())
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# ensure_master_key
+# ---------------------------------------------------------------------------
+
+class TestEnsureMasterKey:
+    def test_generates_when_env_missing(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env_path = tmp_path / ".env"
+        assert not env_path.exists()
+
+        was_generated, key = ensure_master_key(env_path)
+
+        assert was_generated is True
+        assert key  # non-empty
+        assert _is_valid_fernet_key(key)
+        assert env_path.exists()
+        assert f"KNOWLEDGE_MASTER_KEY={key}" in env_path.read_text()
+
+    def test_generates_when_key_absent(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("OTHER_KEY=abc123\nANOTHER=xyz\n")
+
+        was_generated, key = ensure_master_key(env_path)
+
+        assert was_generated is True
+        assert _is_valid_fernet_key(key)
+        content = env_path.read_text()
+        # Existing content preserved
+        assert "OTHER_KEY=abc123" in content
+        assert "ANOTHER=xyz" in content
+        # New key appended
+        assert f"KNOWLEDGE_MASTER_KEY={key}" in content
+
+    def test_noop_when_key_present(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+        from cryptography.fernet import Fernet
+
+        existing_key = Fernet.generate_key().decode()
+        env_path = tmp_path / ".env"
+        env_path.write_text(f"KNOWLEDGE_MASTER_KEY={existing_key}\nFOO=bar\n")
+        original_content = env_path.read_text()
+
+        was_generated, key = ensure_master_key(env_path)
+
+        assert was_generated is False
+        assert key == existing_key
+        # File must be unchanged on no-op
+        assert env_path.read_text() == original_content
+
+    def test_idempotent(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env_path = tmp_path / ".env"
+        # First call: generates
+        g1, k1 = ensure_master_key(env_path)
+        assert g1 is True
+        # Second call: no-op
+        g2, k2 = ensure_master_key(env_path)
+        assert g2 is False
+        assert k2 == k1
+        # Third call: still no-op
+        g3, k3 = ensure_master_key(env_path)
+        assert g3 is False
+        assert k3 == k1
+        # Only one entry in the file
+        assert env_path.read_text().count("KNOWLEDGE_MASTER_KEY=") == 1
+
+    def test_creates_parent_dir_if_missing(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env_path = tmp_path / "deep" / "nested" / ".env"
+        was_generated, _ = ensure_master_key(env_path)
+
+        assert was_generated is True
+        assert env_path.exists()
+        assert env_path.parent.is_dir()
+
+    def test_quoted_value_is_recognized(self, tmp_path):
+        """Naive .env parsers leave quotes around values; we still detect the key."""
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+        from cryptography.fernet import Fernet
+
+        existing_key = Fernet.generate_key().decode()
+        env_path = tmp_path / ".env"
+        env_path.write_text(f'KNOWLEDGE_MASTER_KEY="{existing_key}"\n')
+
+        was_generated, key = ensure_master_key(env_path)
+        assert was_generated is False
+        assert key == existing_key
+
+    def test_generated_key_is_different_each_fresh_run(self, tmp_path):
+        """Two fresh generations should not collide — Fernet is cryptographically random."""
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env1 = tmp_path / "env1" / ".env"
+        env2 = tmp_path / "env2" / ".env"
+        _, k1 = ensure_master_key(env1)
+        _, k2 = ensure_master_key(env2)
+        assert k1 != k2
+
+    def test_file_mode_600_on_posix(self, tmp_path):
+        _add_backend()
+        from knowledge.cli import ensure_master_key
+
+        env_path = tmp_path / ".env"
+        ensure_master_key(env_path)
+
+        if os.name == "posix":
+            mode = env_path.stat().st_mode & 0o777
+            assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+        # On Windows chmod is best-effort; we don't assert anything there.
+
+
+# ---------------------------------------------------------------------------
+# cmd_init_key — CLI wrapper (smoke test only; output goes to stdout)
+# ---------------------------------------------------------------------------
+
+class TestCmdInitKey:
+    def test_returns_zero_on_fresh_generation(self, tmp_path, monkeypatch, capsys):
+        _add_backend()
+        # Monkeypatch _find_env_file to point into our tmp dir
+        from knowledge import cli as cli_mod
+        env_path = tmp_path / ".env"
+        monkeypatch.setattr(cli_mod, "_find_env_file", lambda: env_path)
+
+        rc = cli_mod.cmd_init_key([])
+        assert rc == 0
+        assert env_path.exists()
+        assert "KNOWLEDGE_MASTER_KEY=" in env_path.read_text()
+
+        out = capsys.readouterr().out
+        assert "generated" in out.lower()
+
+    def test_returns_zero_on_existing_key(self, tmp_path, monkeypatch, capsys):
+        _add_backend()
+        from knowledge import cli as cli_mod
+        from cryptography.fernet import Fernet
+
+        key = Fernet.generate_key().decode()
+        env_path = tmp_path / ".env"
+        env_path.write_text(f"KNOWLEDGE_MASTER_KEY={key}\n")
+        monkeypatch.setattr(cli_mod, "_find_env_file", lambda: env_path)
+
+        rc = cli_mod.cmd_init_key([])
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        assert "already" in out.lower()
+        assert "no-op" in out.lower()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,34 @@ if ! grep -q '^EVONEXUS_SECRET_KEY=' "$CONFIG_DIR/.env" 2>/dev/null; then
     echo "EVONEXUS_SECRET_KEY=$(openssl rand -hex 32)" >> "$CONFIG_DIR/.env"
 fi
 
+# --- 3b. Ensure KNOWLEDGE_MASTER_KEY exists (Knowledge Base DSN encryption) ---
+# Without this, /api/knowledge/* endpoints raise on startup and the Knowledge
+# section of the dashboard fails to load. Fernet requires a urlsafe-base64
+# encoded 32-byte key, so `openssl rand` cannot be used directly — we go
+# through Python's cryptography lib (already installed in the venv via
+# pyproject.toml). Generated once on first boot; the UI never exposes it.
+if ! grep -q '^KNOWLEDGE_MASTER_KEY=' "$CONFIG_DIR/.env" 2>/dev/null; then
+    # Prefer the venv python (has `cryptography` pinned); fall back to system.
+    _PYBIN="/workspace/.venv/bin/python3"
+    [ -x "$_PYBIN" ] || _PYBIN="$(command -v python3 || true)"
+    if [ -n "$_PYBIN" ]; then
+        _KEY=$("$_PYBIN" -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())" 2>/dev/null || true)
+        if [ -n "$_KEY" ]; then
+            {
+                printf '\n# Knowledge encryption key — DO NOT delete, DO NOT commit.\n'
+                printf '# Losing this key = losing access to ALL configured connections.\n'
+                printf 'KNOWLEDGE_MASTER_KEY=%s\n' "$_KEY"
+            } >> "$CONFIG_DIR/.env"
+            echo "[$(date -Is)] Generated KNOWLEDGE_MASTER_KEY (first boot)" >&2
+        else
+            echo "[$(date -Is)] WARNING: could not generate KNOWLEDGE_MASTER_KEY (cryptography missing?)" >&2
+        fi
+    else
+        echo "[$(date -Is)] WARNING: no python3 found — KNOWLEDGE_MASTER_KEY not generated" >&2
+    fi
+    unset _PYBIN _KEY
+fi
+
 # --- 4. Symlinks so the app finds files at the paths it expects ------------
 ln -sfn "$CONFIG_DIR/.env" /workspace/.env
 if [ ! -e /workspace/CLAUDE.md ] && [ ! -L /workspace/CLAUDE.md ]; then

--- a/setup.py
+++ b/setup.py
@@ -786,6 +786,39 @@ def copy_env_example(config: dict):
         dst.write_text("# EvoNexus Environment Variables\n# Fill in your API keys below\n\n", encoding="utf-8")
 
 
+def ensure_knowledge_master_key(config: dict):
+    """Generate KNOWLEDGE_MASTER_KEY on first setup so the Knowledge Base
+    (pgvector-knowledge) works out of the box — no need for the user to run
+    `evonexus init-key` manually.
+
+    Idempotent: a key that already exists is preserved.
+    Safe: failure is non-fatal — Knowledge features will error clearly at
+    first use and the user can still run `make init-key` manually.
+    """
+    env_path = WORKSPACE / ".env"
+    try:
+        # Import lazily so a missing cryptography (pre-`uv sync`) does not
+        # break the rest of the setup wizard.
+        sys.path.insert(0, str(WORKSPACE / "dashboard" / "backend"))
+        from knowledge.cli import ensure_master_key
+        was_generated, _ = ensure_master_key(env_path)
+    except RuntimeError as exc:
+        # cryptography not installed yet — acceptable; uv sync will fix
+        # on the next line and the user can re-run this step if needed.
+        print(f"  {YELLOW}!{RESET} Skipped KNOWLEDGE_MASTER_KEY generation ({exc})")
+        print(f"    {DIM}Run `make init-key` after setup completes to generate it.{RESET}")
+        return
+    except Exception as exc:  # noqa: BLE001 — never block setup on this
+        print(f"  {YELLOW}!{RESET} Could not ensure KNOWLEDGE_MASTER_KEY: {exc}")
+        print(f"    {DIM}Run `make init-key` after setup completes to generate it.{RESET}")
+        return
+
+    if was_generated:
+        print(f"  {GREEN}✓{RESET} Generated KNOWLEDGE_MASTER_KEY (Knowledge Base encryption)")
+    else:
+        print(f"  {DIM}  KNOWLEDGE_MASTER_KEY already set — preserved{RESET}")
+
+
 def copy_routines_config(config: dict):
     dst = WORKSPACE / "config" / "routines.yaml"
     if dst.exists():
@@ -920,6 +953,9 @@ def main():
 
     # .env
     copy_env_example(config)
+
+    # KNOWLEDGE_MASTER_KEY (idempotent; generated on first setup)
+    ensure_knowledge_master_key(config)
 
     # routines.yaml
     copy_routines_config(config)


### PR DESCRIPTION
## Summary

Generates `KNOWLEDGE_MASTER_KEY` automatically during:
1. `make setup` (interactive wizard — `setup.py`)
2. Docker / Swarm first boot (`entrypoint.sh`)

…so a fresh install **just works** for the Knowledge Base without requiring
the user to notice an error and run `make init-key` manually.

## Why

Today, a fresh install of EvoNexus fails at the Knowledge Base surface
until the user runs `make init-key` or `evonexus init-key`:

* `/api/knowledge/*` endpoints raise on startup (`KNOWLEDGE_MASTER_KEY` is
  asserted at request time)
* Dashboard → Knowledge section fails to load
* The only error the user sees is a 500 in the browser console

This is a small paper cut but a real one for first-time users following
the v0.25.0 Knowledge Base onboarding. It also contradicts the
UI-first / first-boot-auto philosophy the project already applies to
`EVONEXUS_SECRET_KEY` (see `entrypoint.sh` line 49-53 on develop).

## Changes

### `dashboard/backend/knowledge/cli.py`

* Extract the generator into a reusable
  `ensure_master_key(env_path) -> (was_generated, key)` function.
* Idempotent: preserves any existing key; generates a Fernet key only
  when missing.
* `cmd_init_key` is now a thin wrapper — existing CLI surface preserved.

### `setup.py`

* New `ensure_knowledge_master_key(config)` step called right after
  `copy_env_example`. Prints a green check when a key is generated and
  a dim note when one already exists.
* Failure is non-fatal: if `cryptography` is not installed yet (rare —
  `uv sync` hasn't run) the wizard continues and points the user at
  `make init-key` as a fallback.

### `entrypoint.sh`

* New block **3b**, immediately after the existing `EVONEXUS_SECRET_KEY`
  block — same idempotent `grep -q '^KNOWLEDGE_MASTER_KEY='` guard.
* `openssl rand` cannot produce a Fernet key (Fernet requires urlsafe-
  base64 encoded 32 bytes), so we call Python with the venv's
  `cryptography` lib. Prefer `/workspace/.venv/bin/python3`; fall back
  to system `python3`.
* If neither Python path has `cryptography`, logs a clear WARNING on
  stderr and the container still starts — matches the existing
  `REQUIRE_ANTHROPIC_KEY` fail-soft pattern.

### Tests (new file)

`dashboard/backend/knowledge/tests/test_cli.py` — **10 tests, all pass**:

| Test | Behavior verified |
|---|---|
| generates_when_env_missing | Creates .env and fills key |
| generates_when_key_absent | Appends to existing .env without touching other keys |
| noop_when_key_present | Byte-identical file on repeat calls |
| idempotent | Multiple calls = 1 entry |
| creates_parent_dir_if_missing | mkdir -p behavior |
| quoted_value_is_recognized | Tolerates \`KEY=\"value\"\` style |
| generated_key_is_different_each_fresh_run | Cryptographic randomness |
| file_mode_600_on_posix | chmod after write |
| cmd_init_key returns_zero_on_fresh_generation | CLI wrapper exit code |
| cmd_init_key returns_zero_on_existing_key | CLI no-op exit code |

## Testing

* `PYTHONPATH=. pytest knowledge/tests/test_cli.py -v` — **10 passed**
* `bash -n entrypoint.sh` — syntax clean
* Manual: verified Fernet key round-trip matches the production layout
  (`python:3.12-slim` + `uv sync` → `/workspace/.venv/bin/python3`)

## Breaking changes

**None.**

* `make init-key` / `evonexus init-key` still work byte-for-byte
  identically (they now go through the new helper under the hood).
* Users with an existing key in `.env` see zero behavior change — the
  idempotent guard preserves their key.
* No new env var required. No new secret to rotate.

## Closes

This pairs well with — but is independent of — the upcoming Gemini embedder
PR. Either can land first.