### PR TITLE
fix(setup): persist firewall rules across reboot + report errors instead of swallowing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,13 @@ MESSAGES = {
         "nginx_config_failed": "Failed to configure nginx",
         "configuring_firewall": "Configuring firewall...",
         "firewall_ports_opened": "Firewall ports opened (80, 443)",
+        "firewall_using_ufw": "Using ufw",
+        "firewall_using_iptables": "Using iptables (ufw not installed)",
+        "firewall_persisted": "Rules persisted via {tool} (will survive reboot)",
+        "firewall_persistence_missing": "Rules opened in memory only — install netfilter-persistent OR ufw to persist across reboots",
+        "firewall_install_persistence": "Installing netfilter-persistent so rules survive reboot...",
+        "firewall_failed": "Firewall step failed: {err}",
+        "firewall_cloud_provider_hint": "Cloud provider firewall: if 80/443 still appear blocked from outside, also open them in your provider's Security List/Group ({provider}).",
         # Workspace file creation
         "generated_workspace_yaml": "Generated config/workspace.yaml",
         "env_created_from_example": "Created .env from .env.example",
@@ -324,6 +331,13 @@ MESSAGES = {
         "nginx_config_failed": "Falha ao configurar o nginx",
         "configuring_firewall": "Configurando firewall...",
         "firewall_ports_opened": "Portas do firewall abertas (80, 443)",
+        "firewall_using_ufw": "Usando ufw",
+        "firewall_using_iptables": "Usando iptables (ufw não instalado)",
+        "firewall_persisted": "Regras persistidas via {tool} (vão sobreviver ao reboot)",
+        "firewall_persistence_missing": "Regras abertas só na memória — instale netfilter-persistent OU ufw para persistir entre reboots",
+        "firewall_install_persistence": "Instalando netfilter-persistent para persistir regras no reboot...",
+        "firewall_failed": "Etapa do firewall falhou: {err}",
+        "firewall_cloud_provider_hint": "Firewall do provedor: se 80/443 ainda aparecerem bloqueados de fora, abra também na Security List/Group do seu provedor ({provider}).",
         # Workspace file creation
         "generated_workspace_yaml": "Gerado config/workspace.yaml",
         "env_created_from_example": "Criado .env a partir do .env.example",
@@ -486,6 +500,13 @@ MESSAGES = {
         "nginx_config_failed": "Error al configurar nginx",
         "configuring_firewall": "Configurando firewall...",
         "firewall_ports_opened": "Puertos del firewall abiertos (80, 443)",
+        "firewall_using_ufw": "Usando ufw",
+        "firewall_using_iptables": "Usando iptables (ufw no está instalado)",
+        "firewall_persisted": "Reglas persistidas vía {tool} (sobrevivirán al reinicio)",
+        "firewall_persistence_missing": "Reglas abiertas solo en memoria — instala netfilter-persistent O ufw para persistir entre reinicios",
+        "firewall_install_persistence": "Instalando netfilter-persistent para que las reglas sobrevivan al reinicio...",
+        "firewall_failed": "El paso del firewall falló: {err}",
+        "firewall_cloud_provider_hint": "Firewall del proveedor: si 80/443 siguen bloqueados desde fuera, ábrelos también en la Security List/Group de tu proveedor ({provider}).",
         # Workspace file creation
         "generated_workspace_yaml": "Generado config/workspace.yaml",
         "env_created_from_example": "Creado .env desde .env.example",
@@ -831,6 +852,130 @@ def check_prerequisites():
     return True
 
 
+def _detect_cloud_provider() -> str | None:
+    """Best-effort cloud-provider detection for the firewall hint message.
+
+    Looks at /sys/class/dmi/id/* (set by the BIOS/hypervisor) — non-fatal
+    if unreadable. Returns a short human-readable label or None.
+    """
+    sources = [
+        ("/sys/class/dmi/id/sys_vendor", {"oraclecloud": "Oracle Cloud (OCI)", "amazon ec2": "AWS EC2",
+                                          "google": "Google Cloud", "microsoft": "Azure", "digitalocean": "DigitalOcean",
+                                          "hetzner": "Hetzner Cloud"}),
+        ("/sys/class/dmi/id/chassis_asset_tag", {"oraclecloud": "Oracle Cloud (OCI)",
+                                                  "amazon": "AWS EC2", "google": "Google Cloud"}),
+    ]
+    for path, mapping in sources:
+        try:
+            with open(path) as f:
+                value = f.read().strip().lower()
+            for needle, label in mapping.items():
+                if needle in value:
+                    return label
+        except OSError:
+            continue
+    return None
+
+
+def _open_firewall_ports(ports: list[int]) -> None:
+    """Open inbound TCP ports robustly and PERSISTENTLY.
+
+    The previous one-liner used ``2>/dev/null`` everywhere, so any failure
+    (ufw missing, iptables-nft refusing the rule, no permission) was
+    silently swallowed and the wizard happily printed "Firewall ports
+    opened" while nothing actually changed. Worse, it never persisted
+    the rules, so on the first reboot the in-memory iptables additions
+    vanished and the dashboard was unreachable from outside.
+
+    Strategy:
+      1. Prefer ``ufw`` when present — handles persistence itself.
+      2. Otherwise use ``iptables -C`` to check before ``-I`` (idempotent
+         re-runs on the same machine don't pile up duplicate rules).
+      3. Persist via ``netfilter-persistent save`` if available; if not
+         and we're on a Debian/Ubuntu system, install
+         ``iptables-persistent`` non-interactively then save.
+      4. If everything we tried fails, surface the actual error rather
+         than reporting success.
+      5. Always emit a hint about cloud-provider security lists — Oracle
+         Cloud, AWS, GCP, etc. enforce a separate network firewall that
+         no host-level command can bypass.
+    """
+    print(f"  {DIM}{T('configuring_firewall')}{RESET}")
+    if os.getuid() != 0:
+        # Non-root: we can't open the firewall anyway. Just hint.
+        print(f"  {YELLOW}!{RESET} {T('firewall_persistence_missing')}")
+        return
+
+    backend_used = None
+    errors: list[str] = []
+
+    if shutil.which("ufw"):
+        backend_used = "ufw"
+        print(f"  {DIM}  {T('firewall_using_ufw')}{RESET}")
+        for p in ports:
+            rc = os.system(f"ufw allow {p}/tcp >/dev/null 2>&1")
+            if rc != 0:
+                errors.append(f"ufw allow {p}/tcp (rc={rc >> 8})")
+    elif shutil.which("iptables"):
+        backend_used = "iptables"
+        print(f"  {DIM}  {T('firewall_using_iptables')}{RESET}")
+        for p in ports:
+            # -C tests whether the rule already exists; -I inserts at
+            # the top of INPUT only when it doesn't (idempotent).
+            check = os.system(f"iptables -C INPUT -p tcp --dport {p} -j ACCEPT >/dev/null 2>&1")
+            if check != 0:
+                rc = os.system(f"iptables -I INPUT -p tcp --dport {p} -j ACCEPT 2>/dev/null")
+                if rc != 0:
+                    errors.append(f"iptables -I {p} (rc={rc >> 8})")
+    else:
+        errors.append("neither ufw nor iptables available")
+
+    # Persistence — the actual fix for "works after install, dies on reboot".
+    persistence_tool = None
+    if backend_used == "ufw":
+        # ufw persists by default
+        persistence_tool = "ufw"
+    elif backend_used == "iptables":
+        if shutil.which("netfilter-persistent"):
+            rc = os.system("netfilter-persistent save >/dev/null 2>&1")
+            if rc == 0:
+                persistence_tool = "netfilter-persistent"
+            else:
+                errors.append(f"netfilter-persistent save (rc={rc >> 8})")
+        elif shutil.which("apt-get"):
+            print(f"  {DIM}  {T('firewall_install_persistence')}{RESET}")
+            os.system(
+                "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "
+                "iptables-persistent netfilter-persistent >/dev/null 2>&1"
+            )
+            if shutil.which("netfilter-persistent"):
+                rc = os.system("netfilter-persistent save >/dev/null 2>&1")
+                if rc == 0:
+                    persistence_tool = "netfilter-persistent"
+                else:
+                    errors.append(f"netfilter-persistent save (rc={rc >> 8})")
+            else:
+                # Last-resort manual save
+                os.makedirs("/etc/iptables", exist_ok=True)
+                rc = os.system("iptables-save > /etc/iptables/rules.v4 2>/dev/null")
+                if rc == 0:
+                    persistence_tool = "/etc/iptables/rules.v4"
+
+    # Result reporting — no more silent success.
+    if errors:
+        print(f"  {YELLOW}!{RESET} {T('firewall_failed', err='; '.join(errors))}")
+    else:
+        print(f"  {GREEN}✓{RESET} {T('firewall_ports_opened')}")
+    if persistence_tool:
+        print(f"  {GREEN}✓{RESET} {T('firewall_persisted', tool=persistence_tool)}")
+    else:
+        print(f"  {YELLOW}!{RESET} {T('firewall_persistence_missing')}")
+
+    cloud = _detect_cloud_provider()
+    if cloud:
+        print(f"  {DIM}  {T('firewall_cloud_provider_hint', provider=cloud)}{RESET}")
+
+
 def configure_access() -> dict:
     """Configure how the dashboard will be accessed (local or domain with SSL)."""
     print(f"\n  {BOLD}{T('dashboard_access')}{RESET}\n")
@@ -997,10 +1142,7 @@ server {{
         print(f"  {YELLOW}!{RESET} {T('nginx_no_permission')}")
 
     # Step 5: Open firewall ports
-    print(f"  {DIM}{T('configuring_firewall')}{RESET}")
-    os.system("ufw allow 80/tcp 2>/dev/null; ufw allow 443/tcp 2>/dev/null; ufw allow 8080/tcp 2>/dev/null; ufw allow 32352/tcp 2>/dev/null")
-    os.system("iptables -I INPUT -p tcp --dport 80 -j ACCEPT 2>/dev/null; iptables -I INPUT -p tcp --dport 443 -j ACCEPT 2>/dev/null")
-    print(f"  {GREEN}✓{RESET} {T('firewall_ports_opened')}")
+    _open_firewall_ports([80, 443, 8080, 32352])
 
     return {"mode": "domain", "url": f"https://{domain}"}
 


### PR DESCRIPTION
## Summary

Reproduced on Oracle Cloud (Ubuntu 24.04 cloud image): the wizard prints "Firewall ports opened (80, 443)" but the dashboard is unreachable from outside, and after a reboot the iptables rules vanish entirely. Cloudflare returns 523 "Origin Unreachable" for the duration.

## Repro

```bash
sudo git clone --branch develop https://github.com/EvolutionAPI/evo-nexus.git /root/evonexus
cd /root/evonexus && make setup   # answer "Domain with SSL"
# wizard finishes, prints "✓ Portas do firewall abertas (80, 443)"
sudo iptables-save | grep -E 'dport (80|443)'
# → empty. The "✓" was a lie.
sudo reboot
# … even if the rules WERE in memory, they're gone now
```

## Root cause

Three bugs in the original one-liner:

```python
os.system("ufw allow 80/tcp 2>/dev/null; ufw allow 443/tcp 2>/dev/null; ...")
os.system("iptables -I INPUT -p tcp --dport 80 -j ACCEPT 2>/dev/null; ...")
print("✓ Firewall ports opened (80, 443)")  # always prints
```

1. **`2>/dev/null` swallows every error.** OCI/Ubuntu cloud images don't ship `ufw` — every ufw line silently fails. The iptables fallback often runs, but if it errors (permission, nf_tables backend rejection, missing CAP_NET_ADMIN inside a container) you'd never know.
2. **Nothing calls `netfilter-persistent save`** (or writes to `/etc/iptables/rules.v4`). Even when iptables -I succeeds, the next reboot reloads the persistent ruleset which doesn't include 80/443 → dashboard offline until the operator manually re-runs setup.
3. **Re-running the wizard adds duplicate ACCEPT rules** each time (no `-C` check before `-I`).

## Fix

New helper `_open_firewall_ports(ports)`:

- Prefers `ufw` when present (handles persistence itself).
- Falls back to `iptables`, with `-C` idempotency check before `-I` (re-runs on the same machine don't pile up duplicate rules).
- **Persists via `netfilter-persistent save`** — auto-installs `iptables-persistent` non-interactively on Debian/Ubuntu if missing. Last-resort fallback writes `/etc/iptables/rules.v4` directly.
- Surfaces actual errors instead of silencing them. Reports which backend was used and which persistence path succeeded.
- Best-effort cloud-provider detection (OCI, AWS, GCP, Azure, DigitalOcean, Hetzner) via `/sys/class/dmi/id/*` — prints a hint that host-level firewall changes alone may not be enough; the operator likely also needs to open the port in the cloud Security List/Group/NSG. **No host-level command can fix the cloud network firewall** — but a clear hint saves hours of debugging "523 Origin Unreachable" from Cloudflare.

7 new translation keys, mirrored across en-US / pt-BR / es. Bundles remain at exact key parity (160 each).

## Test plan

- [x] `python -c "import ast; ast.parse(open('setup.py',encoding='utf-8').read())"` — clean parse
- [x] Translation parity — all 3 bundles at 160 keys, set-diff empty, every new format string survives `.format(tool=, err=, provider=)`
- [x] Oracle Cloud Ubuntu 24.04: rules go in via iptables, persist via netfilter-persistent, survive reboot. Hint about OCI Security List shown.
- [x] Ubuntu desktop with ufw: rules go in via ufw, persist automatically, no extra hint shown.
- [x] Re-running wizard: idempotent (no duplicate INPUT rules).
- [ ] Operator validation on OCI: clean install → reboot → `iptables-save | grep dport` shows 80 + 443 → `curl -I https://<domain>/` from a different machine returns 200.

## Breaking changes

**None.**

- The behavior is strictly a superset: when ufw was working before, it still works now (and was already auto-persistent).
- When iptables was the active backend, rules are now persisted instead of vanishing — that's the bug fix.
- The cloud-provider hint is informational; if no provider is detected (bare metal, unknown hypervisor), nothing extra is printed.
- No new mandatory dependencies; `iptables-persistent` is auto-installed only when iptables is the active backend AND `apt-get` is available.
