### PR TITLE
fix(knowledge): run first health check ~5s after boot instead of after 5min

### DIFF
--- a/dashboard/backend/knowledge/health_check.py
+++ b/dashboard/backend/knowledge/health_check.py
@@ -122,10 +122,20 @@ def _schedule_hc(get_app_fn) -> None:
 
 
 def start_health_check_thread(get_app_fn) -> None:
-    """Start the background health check scheduler (idempotent)."""
-    global _hc_started
+    """Start the background health check scheduler (idempotent).
+
+    Runs the first pass on a short-delay timer (not inline) so app startup
+    isn't blocked by slow/unreachable Postgres connections. Without this
+    initial pass, the classify_worker would spam the log for up to
+    _INTERVAL_S (5 min) on boot if a connection is offline, because stale
+    status='ready' from the last session won't be reconciled until the
+    first scheduled tick.
+    """
+    global _hc_started, _hc_timer
     with _hc_lock:
         if _hc_started:
             return
         _hc_started = True
-    _schedule_hc(get_app_fn)
+    _hc_timer = threading.Timer(5.0, _hc_loop, args=(get_app_fn,))
+    _hc_timer.daemon = True
+    _hc_timer.start()


### PR DESCRIPTION
## Summary

- The Knowledge health-check scheduler fires every 5 min (ADR-005). Before this fix, the very first tick was also 5 min after boot.
- If a connection's Postgres went offline between two dashboard runs, SQLite still had `status='ready'` from the previous session. During those 5 min of grace, the `classify_worker` polled every 10s, logging `connection refused` each time (~30 errors per offline connection).
- Fix: schedule the first pass on a 5s delay timer instead of 300s. Keeps it off the request-handling thread (so boot isn't blocked if the Postgres handshake is slow), but reconciles stale status well before the worker has time to spam.

## Test plan

- [x] Syntax check passes
- [ ] Reboot dashboard with an offline Knowledge Postgres → `classify_worker` should log at most 1-2 errors before `status` flips to `disconnected` (instead of ~30)
- [ ] Reboot dashboard with an online Postgres → no regression, `last_health_check` updates within ~10s of boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Knowledge health check startup behavior to run an initial check shortly after boot instead of waiting for the regular interval.

Bug Fixes:
- Ensure Knowledge connection health is reconciled within seconds of dashboard boot to prevent classify_worker from spamming errors when Postgres is offline.

Enhancements:
- Document the health check thread startup semantics and rationale in the start_health_check_thread docstring.