### PR TITLE
ci(docker): publish multi-arch images (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 emulation on amd64 runners)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -79,6 +84,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action@v3` to the Swarm publish workflow and pass `platforms: linux/amd64,linux/arm64` to `build-push-action` so every tag ships a **multi-arch manifest**.

## Why
Single-arch (amd64) images break pulls on ARM hosts:
- Mac Apple Silicon (M1/M2/M3) — `docker pull` fails with `no matching manifest for linux/arm64/v8`
- AWS Graviton instances, Oracle Cloud ARM free tier, Raspberry Pi, many modern VPS
- With the current v0.30.2 image, users on those platforms get the error I hit when smoke-testing the release.

Publishing multi-arch is the standard today — all base images we use (`node:22-alpine`, `node:22-slim`, `python:3.12-slim`) already ship manifest lists for both archs, and `node-pty` compiles from source via node-gyp so no prebuilt-binary-per-arch concern.

## Trade-off
The arm64 build runs under QEMU emulation on amd64 runners, so the pipeline gets ~2-3x slower (build-push cache-from/cache-to is already enabled, which will soften the ongoing cost after the first run).

## Test plan
- [ ] Merge → open PR that becomes next release (v0.30.3).
- [ ] On the next tag push, confirm `docker buildx imagetools inspect evoapicloud/evo-nexus-dashboard:v0.30.3` lists both `linux/amd64` and `linux/arm64` in the manifest.
- [ ] `docker pull evoapicloud/evo-nexus-dashboard:v0.30.3` on Mac Apple Silicon works without `--platform` override.
- [ ] Deploy on an ARM VPS (Oracle/Graviton) → container comes up, dashboard responds on :8080.

## Summary by Sourcery

CI:
- Update the Docker publish GitHub Actions workflow to enable QEMU emulation and buildx multi-platform builds for linux/amd64 and linux/arm64 images.