### PR TITLE
fix(entrypoint): race condition on shared config volume + Docker install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Social media accounts (YouTube, Instagram, LinkedIn) are connected via OAuth thr
 
 ## Prerequisites
 
+**For the Docker install** (easiest — the container ships everything):
+
+| Tool | Required | Install |
+|------|----------|---------|
+| **Docker Engine 24+** | Yes | [docs.docker.com/engine/install](https://docs.docker.com/engine/install/) |
+
+That's it. The image includes Claude Code, Python, Node, uv, gh, and every other runtime dependency.
+
+**For the CLI / from-source install** (the dev flow):
+
 | Tool | Required | Install |
 |------|----------|---------|
 | **Claude Code** | Yes | `npm install -g @anthropic-ai/claude-code` ([docs](https://claude.ai/download)) |
@@ -150,15 +160,27 @@ The setup wizard asks which provider you want during `make setup`, and you can s
 
 > **Starting out?** After installing, open Claude Code and call **`/oracle`**. It's the official entry point of EvoNexus: runs the initial setup, interviews you about your business, shows what the toolkit can automate for you, and delivers a **phased activation plan** — an index file at the top + one folder per phase + one file per item, each with suggested agent team, dependencies, and pending decisions. The plan is materialized by the `prod-activation-plan` skill (workspace canonical pattern) so you never have to guess the next step.
 
-### Method 1 — One command (recommended)
+### Method 1 — Docker (no setup, runs anywhere)
+
+The fastest way. Pulls official multi-arch images (`linux/amd64` + `linux/arm64`) from Docker Hub — works natively on Apple Silicon, AWS Graviton, Oracle ARM, Raspberry Pi, and x86_64 servers.
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+docker compose -f docker-compose.hub.yml up -d
+open http://localhost:8080
+```
+
+The setup wizard loads on first boot. Paste your Anthropic / OpenAI / Codex key and you're done — no extra tooling on your host. Full guide: [docs/guides/docker-install.md](docs/guides/docker-install.md).
+
+### Method 2 — One command (for CLI / terminal workflow)
 
 ```bash
 npx @evoapi/evo-nexus
 ```
 
-This downloads and runs the interactive setup wizard automatically.
+This downloads and runs the interactive setup wizard automatically. Requires the CLI prerequisites above (Claude Code, Python, Node, uv).
 
-### Method 2 — Manual clone
+### Method 3 — Manual clone (for developers / contributors)
 
 ```bash
 git clone --depth 1 https://github.com/EvolutionAPI/evo-nexus.git

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -1,0 +1,106 @@
+# ============================================================================
+# EvoNexus — docker-compose.yml para usuários finais (imagens do Docker Hub)
+#
+# Uso rápido:
+#   $ curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+#   $ docker compose -f docker-compose.hub.yml up -d
+#   $ open http://localhost:8080
+#
+# Tudo (providers, integrações, chaves de API, secrets) é configurado
+# pela UI após o primeiro boot — abra http://localhost:8080 e siga o
+# wizard. Nenhum arquivo .env precisa ser editado à mão.
+#
+# Para DEVS que querem buildar a imagem local a partir do código-fonte,
+# veja docker-compose.yml (que usa `build:` em vez de `image:`).
+#
+# Para produção em Docker Swarm / Portainer, veja evonexus.stack.yml
+# e README.swarm.md.
+# ============================================================================
+
+services:
+  # Dashboard — Flask + React + terminal embutido + Claude CLI
+  # Abra http://localhost:8080 após o boot.
+  dashboard:
+    image: evoapicloud/evo-nexus-dashboard:latest
+    container_name: evonexus-dashboard
+    ports:
+      - "8080:8080"     # Dashboard (UI + API)
+      - "32352:32352"   # Terminal server (WebSocket)
+    environment:
+      - TZ=America/Sao_Paulo
+      - EVONEXUS_PORT=8080
+      - TERMINAL_SERVER_PORT=32352
+      - FORWARDED_ALLOW_IPS=*
+    volumes:
+      # Volumes nomeados mantêm a configuração entre reinícios.
+      # Tudo que você configurar pela UI (providers, integrações, chaves)
+      # vive em `evonexus_config`.
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_dashboard_data:/workspace/dashboard/data
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Telegram — bot que escuta mensagens e delega para agentes
+  # Opcional: remova este serviço se não for usar Telegram.
+  # Espera ANTHROPIC_API_KEY aparecer no .env (configurado pela UI) antes
+  # de iniciar — não fica em crash-loop enquanto você configura.
+  telegram:
+    image: evoapicloud/evo-nexus-runtime:latest
+    container_name: evonexus-telegram
+    command: ["claude", "--channels", "plugin:telegram@claude-plugins-official", "--dangerously-skip-permissions"]
+    environment:
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    depends_on:
+      dashboard:
+        condition: service_healthy
+
+  # Scheduler — executa rotinas automáticas (daily, weekly, monthly).
+  # Opcional: remova este serviço se não for usar rotinas automatizadas.
+  scheduler:
+    image: evoapicloud/evo-nexus-runtime:latest
+    container_name: evonexus-scheduler
+    command: ["uv", "run", "python", "scheduler.py"]
+    environment:
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    restart: unless-stopped
+    depends_on:
+      dashboard:
+        condition: service_healthy
+
+# ----------------------------------------------------------------------------
+# Volumes nomeados — seus dados vivem aqui. Backup: `docker volume ls` +
+# `docker run --rm -v evonexus_config:/src -v $PWD:/dst alpine tar czf /dst/config.tgz -C /src .`
+# ----------------------------------------------------------------------------
+volumes:
+  evonexus_config:
+  evonexus_workspace:
+  evonexus_dashboard_data:
+  evonexus_memory:
+  evonexus_adw_logs:
+  evonexus_agent_memory:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,16 @@
 # Getting Started with EvoNexus
 
-## Prerequisites
+## Choose your install method
+
+| Method | Best for | Requires |
+|---|---|---|
+| **[Docker](guides/docker-install.md)** | Anyone who wants a one-command install that works the same on every OS (Linux, macOS, Windows+WSL2, VPS) | Docker Engine 24+ |
+| **CLI (`npx`)** | Users who want to run EvoNexus alongside their existing Claude Code CLI | Claude Code, Python 3.11+, Node 18+, uv |
+| **Manual clone** | Developers who want to modify source | git, Claude Code, Python 3.11+, Node 18+, uv |
+
+Pick the Docker flow if you're unsure. Keep reading for the CLI flow.
+
+## Prerequisites (CLI flow only)
 
 - **Claude Code CLI** — [Install Claude Code](https://claude.ai/claude-code)
 - **Python 3.11+** with [uv](https://docs.astral.sh/uv/)
@@ -9,7 +19,19 @@
 
 ## Installation
 
-### 1. Quick Install (recommended)
+### Option A — Docker (fastest)
+
+Pulls the official multi-arch images and runs the wizard at http://localhost:8080. Full guide: [Installing with Docker](guides/docker-install.md).
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+docker compose -f docker-compose.hub.yml up -d
+open http://localhost:8080
+```
+
+Skip to [Start with /oracle](#6-use-claude-code--start-with-oracle) after the wizard completes.
+
+### Option B — `npx` (CLI flow)
 
 ```bash
 npx @evoapi/evo-nexus
@@ -17,7 +39,7 @@ npx @evoapi/evo-nexus
 
 This downloads and runs the interactive setup wizard automatically.
 
-### Alternative: Manual Clone
+### Option C — Manual clone
 
 ```bash
 git clone --depth 1 https://github.com/EvolutionAPI/evo-nexus.git

--- a/docs/guides/docker-install.md
+++ b/docs/guides/docker-install.md
@@ -1,0 +1,284 @@
+# Installing EvoNexus with Docker
+
+The fastest way to run EvoNexus on any machine — Linux, macOS (Intel or Apple Silicon), Windows with WSL2, or a bare VPS. Pulls official images from Docker Hub, no source checkout or build step required.
+
+## TL;DR
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+docker compose -f docker-compose.hub.yml up -d
+open http://localhost:8080
+```
+
+The setup wizard on first boot asks for a provider key (Anthropic, OpenAI or Codex). Everything else — integrations, Telegram, Stripe, Omie, Bling, Asaas, etc. — is configured through the UI.
+
+---
+
+## Prerequisites
+
+- **Docker Engine 24+** with Docker Compose v2. [Install on Mac / Windows / Linux](https://docs.docker.com/engine/install/).
+- **4 GB RAM minimum** (8 GB recommended — the Claude CLI and embedding models can be hungry).
+- **2 GB free disk** for images + a few hundred MB for data volumes.
+- An **Anthropic API key** (or OpenAI / ChatGPT Codex account) — you'll paste this into the wizard on first boot.
+
+No Node.js, Python, or any SDK needs to be installed on the host. The images ship everything.
+
+### Multi-arch — ARM64 works out of the box
+
+Images are published as multi-arch manifests (`linux/amd64` + `linux/arm64`), so:
+
+- **Apple Silicon** (M1/M2/M3 Macs) — pulls `arm64` natively, no Rosetta overhead.
+- **AWS Graviton**, **Oracle Cloud ARM free tier**, **Raspberry Pi 4/5** — pulls `arm64` natively.
+- **Traditional x86_64 servers** — pulls `amd64` as usual.
+
+You never pass `--platform`. Docker picks the right arch from the manifest list.
+
+---
+
+## Step 1 — Get the compose file
+
+Download the ready-to-run compose file. It pulls images from `evoapicloud/evo-nexus-{dashboard,runtime}` on Docker Hub — no git clone required.
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+```
+
+Open it — it's commented and self-explanatory. Key things to know:
+
+- **3 services**: `dashboard` (Flask + React + terminal), `telegram` (bot listener), `scheduler` (automated routines). Telegram and scheduler are optional — remove them from the file if you don't need them.
+- **Ports exposed**: `8080` (dashboard UI + API) and `32352` (terminal WebSocket).
+- **Volumes**: 6 named volumes that survive `docker compose down` and hold everything the UI configures.
+
+---
+
+## Step 2 — Start the stack
+
+```bash
+docker compose -f docker-compose.hub.yml up -d
+```
+
+First run downloads the images (~800 MB total, a few minutes depending on your connection). Subsequent boots are instant.
+
+Check that all 3 services are up:
+
+```bash
+docker compose -f docker-compose.hub.yml ps
+```
+
+You should see:
+
+```
+NAME                   STATUS
+evonexus-dashboard     Up (healthy)
+evonexus-telegram      Up
+evonexus-scheduler     Up
+```
+
+If the dashboard takes longer than 30 seconds to go healthy, check logs:
+
+```bash
+docker compose -f docker-compose.hub.yml logs -f dashboard
+```
+
+---
+
+## Step 3 — Open the UI and run the setup wizard
+
+Open **http://localhost:8080** in your browser. You'll see the first-boot wizard:
+
+1. **Create admin user** — username + password for the dashboard itself.
+2. **Pick a provider** — paste your Anthropic API key, OpenAI key, or click "Login with ChatGPT" for Codex OAuth.
+3. **Optional integrations** — Telegram bot token, Stripe, Omie, etc. Everything else is optional and can be added later.
+
+Once you save a provider key, the `telegram` and `scheduler` services (which were waiting in a 30s poll loop) pick it up and start working. No restart needed.
+
+---
+
+## Step 4 — Everyday commands
+
+| Action | Command |
+|---|---|
+| View logs | `docker compose -f docker-compose.hub.yml logs -f` |
+| Restart | `docker compose -f docker-compose.hub.yml restart` |
+| Stop | `docker compose -f docker-compose.hub.yml down` |
+| Stop + wipe data | `docker compose -f docker-compose.hub.yml down -v` ⚠️ |
+| Update to latest | See [Updating](#updating) below |
+
+---
+
+## Updating
+
+### Pull the latest stable image
+
+```bash
+docker compose -f docker-compose.hub.yml pull
+docker compose -f docker-compose.hub.yml up -d
+```
+
+Your data volumes are preserved — everything you configured through the UI stays intact.
+
+### Pin to a specific version
+
+Edit `docker-compose.hub.yml` and replace `:latest` with `:vX.Y.Z` (e.g. `:v0.30.4`). Available tags: https://hub.docker.com/r/evoapicloud/evo-nexus-dashboard/tags
+
+Rolling back is just bumping the tag down and running `pull && up -d`.
+
+---
+
+## Backup and restore
+
+Your configuration, workspace files, memory, and agent state live in 6 named volumes. To snapshot them all:
+
+```bash
+# Backup
+mkdir -p evonexus-backup
+for vol in config workspace dashboard_data memory adw_logs agent_memory; do
+  docker run --rm \
+    -v evonexus_${vol}:/src:ro \
+    -v "$PWD/evonexus-backup":/dst \
+    alpine tar czf /dst/${vol}.tgz -C /src .
+done
+
+# Restore on a fresh host
+for vol in config workspace dashboard_data memory adw_logs agent_memory; do
+  docker volume create evonexus_${vol}
+  docker run --rm \
+    -v evonexus_${vol}:/dst \
+    -v "$PWD/evonexus-backup":/src:ro \
+    alpine tar xzf /src/${vol}.tgz -C /dst
+done
+```
+
+---
+
+## Advanced: passing secrets via environment variables
+
+The default flow is "configure everything through the UI, which writes to a persisted `.env` inside the `evonexus_config` volume." Most users should stick with that.
+
+If you prefer to keep secrets out of the volume (for CI/CD, Vault, Doppler, or immutable infra), you can pass any env var directly in the compose file. They **take precedence** over the volume's `.env`:
+
+```yaml
+services:
+  dashboard:
+    image: evoapicloud/evo-nexus-dashboard:latest
+    environment:
+      - TZ=America/Sao_Paulo
+      - EVONEXUS_PORT=8080
+      # Bypass the UI — pass keys directly
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}      # read from shell or .env.compose
+      - EVONEXUS_SECRET_KEY=${EVONEXUS_SECRET_KEY}
+      - KNOWLEDGE_MASTER_KEY=${KNOWLEDGE_MASTER_KEY}
+    env_file:
+      - ./secrets.env   # or load from a file — this file is NOT inside the volume
+```
+
+Tradeoffs:
+
+- **Pro**: secrets live with the infrastructure, not the user-editable volume. Rotate by redeploying.
+- **Con**: the Providers page in the UI will still work (and will write to the volume's `.env`), but any value you pass via `environment:` wins. This can be confusing for non-technical users.
+
+For the absolutely purist flow, pass `REQUIRE_ANTHROPIC_KEY=0` on the telegram and scheduler services so they don't wait for a UI-saved key — they'll just use whatever is in `environment:`.
+
+---
+
+## Advanced: Docker Secrets
+
+Every env var also supports a `_FILE` counterpart. Point it at a file, and the entrypoint reads the content into the var at boot. This works natively with Docker Secrets in Swarm mode:
+
+```yaml
+services:
+  dashboard:
+    environment:
+      - ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_key
+    secrets:
+      - anthropic_key
+
+secrets:
+  anthropic_key:
+    external: true
+```
+
+Additionally, every file under `/run/secrets/` is auto-discovered: `/run/secrets/anthropic_api_key` → sets `ANTHROPIC_API_KEY` if it's not already set.
+
+---
+
+## Running on a VPS with a public domain
+
+For production on a single-host VPS (not a Swarm cluster), put a reverse proxy in front of `docker-compose.hub.yml`. The simplest path is Caddy:
+
+```yaml
+# Caddyfile next to docker-compose.hub.yml
+evonexus.example.com {
+    reverse_proxy /terminal/* localhost:32352
+    reverse_proxy localhost:8080
+}
+```
+
+Then `caddy run` and you have HTTPS with automatic Let's Encrypt certificates pointing at your EvoNexus stack.
+
+For Docker Swarm with Traefik, see [README.swarm.md](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) and [`evonexus.stack.yml`](https://github.com/EvolutionAPI/evo-nexus/blob/main/evonexus.stack.yml).
+
+---
+
+## Troubleshooting
+
+### Dashboard port 8080 is already in use
+
+Another service on your host is bound to 8080. Change the host port in the compose file:
+
+```yaml
+ports:
+  - "9090:8080"     # host 9090 → container 8080
+```
+
+Then open `http://localhost:9090`.
+
+### Telegram / scheduler logs say "waiting for ANTHROPIC_API_KEY"
+
+Expected. These services poll `.env` every 30s. Configure a provider key in **Dashboard → Providers** and they'll pick it up automatically — no restart needed.
+
+### Services keep restarting after `up -d`
+
+Check logs:
+
+```bash
+docker compose -f docker-compose.hub.yml logs --tail=50 <service>
+```
+
+99% of the time this is either (a) port conflict, (b) volume mount permission issue (rare, usually only on SELinux-enabled hosts — add `:Z` to volume mounts), or (c) disk full.
+
+### Fresh install doesn't show any agents / skills on `/agents` or `/skills`
+
+On a brand-new volume, the APIs return `{"error": "Setup required", "needs_setup": true}` until the wizard completes. Open http://localhost:8080 and complete the wizard first.
+
+### Want to see what's inside the running container
+
+```bash
+docker compose -f docker-compose.hub.yml exec dashboard bash
+```
+
+Useful paths inside the container:
+
+- `/workspace/config/.env` — everything the UI saves (ports, keys, integrations)
+- `/workspace/workspace/` — generated artifacts (reports, dashboards, daily logs)
+- `/workspace/memory/` — long-term memory the agents write
+- `/workspace/.claude/agent-memory/` — per-agent persistent state
+- `/workspace/ADWs/logs/` — routine execution logs (JSONL)
+
+---
+
+## Uninstall
+
+```bash
+docker compose -f docker-compose.hub.yml down -v
+```
+
+The `-v` flag also deletes the named volumes — **all your configuration and data is gone**. Skip the flag to keep volumes around for a future reinstall.
+
+---
+
+## See also
+
+- [Updating EvoNexus](./updating.md) — version bumps across all install methods
+- [README.swarm.md](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) — production Swarm / Portainer deployments with Traefik
+- [Environment variables reference](../reference/env-variables.md) — every variable the image recognizes

--- a/docs/guides/updating.md
+++ b/docs/guides/updating.md
@@ -37,21 +37,32 @@ python app.py &
 
 ## Update via Docker (published images)
 
-Starting with **v0.30.2**, official images are published to Docker Hub under the `evoapicloud` namespace:
+Starting with **v0.30.2**, official multi-arch images (amd64 + arm64) are published to Docker Hub under the `evoapicloud` namespace:
 
 - `evoapicloud/evo-nexus-dashboard` — Flask + React + embedded terminal + Claude CLI
 - `evoapicloud/evo-nexus-runtime` — Node/Python runtime for the Telegram bot and the scheduler
 
 The images are public — no `docker login` required.
 
+### docker compose (single host, from Docker Hub)
+
+If you deployed with [`docker-compose.hub.yml`](https://github.com/EvolutionAPI/evo-nexus/blob/main/docker-compose.hub.yml) (the recommended flow documented in [Installing with Docker](./docker-install.md)):
+
+```bash
+docker compose -f docker-compose.hub.yml pull
+docker compose -f docker-compose.hub.yml up -d
+```
+
+Named volumes are preserved — all your configuration, providers, integrations, and memory stay intact.
+
 ### Docker Swarm / Portainer
 
 Bump the image tag in your stack (or leave `:latest` and force a redeploy). Example:
 
 ```bash
-docker service update --image evoapicloud/evo-nexus-dashboard:v0.30.2 evonexus_evonexus_dashboard
-docker service update --image evoapicloud/evo-nexus-runtime:v0.30.2   evonexus_evonexus_telegram
-docker service update --image evoapicloud/evo-nexus-runtime:v0.30.2   evonexus_evonexus_scheduler
+docker service update --image evoapicloud/evo-nexus-dashboard:v0.30.4 evonexus_evonexus_dashboard
+docker service update --image evoapicloud/evo-nexus-runtime:v0.30.4   evonexus_evonexus_telegram
+docker service update --image evoapicloud/evo-nexus-runtime:v0.30.4   evonexus_evonexus_scheduler
 ```
 
 See [`README.swarm.md`](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) for the full Swarm / Portainer deployment guide and the `evonexus.stack.yml` template.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2404,7 +2404,17 @@ View the full audit log at **Audit Log** in the sidebar (requires `audit:view`).
 
 # Getting Started with EvoNexus
 
-## Prerequisites
+## Choose your install method
+
+| Method | Best for | Requires |
+|---|---|---|
+| **[Docker](guides/docker-install.md)** | Anyone who wants a one-command install that works the same on every OS (Linux, macOS, Windows+WSL2, VPS) | Docker Engine 24+ |
+| **CLI (`npx`)** | Users who want to run EvoNexus alongside their existing Claude Code CLI | Claude Code, Python 3.11+, Node 18+, uv |
+| **Manual clone** | Developers who want to modify source | git, Claude Code, Python 3.11+, Node 18+, uv |
+
+Pick the Docker flow if you're unsure. Keep reading for the CLI flow.
+
+## Prerequisites (CLI flow only)
 
 - **Claude Code CLI** — [Install Claude Code](https://claude.ai/claude-code)
 - **Python 3.11+** with [uv](https://docs.astral.sh/uv/)
@@ -2413,7 +2423,19 @@ View the full audit log at **Audit Log** in the sidebar (requires `audit:view`).
 
 ## Installation
 
-### 1. Quick Install (recommended)
+### Option A — Docker (fastest)
+
+Pulls the official multi-arch images and runs the wizard at http://localhost:8080. Full guide: [Installing with Docker](guides/docker-install.md).
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+docker compose -f docker-compose.hub.yml up -d
+open http://localhost:8080
+```
+
+Skip to [Start with /oracle](#6-use-claude-code--start-with-oracle) after the wizard completes.
+
+### Option B — `npx` (CLI flow)
 
 ```bash
 npx @evoapi/evo-nexus
@@ -2421,7 +2443,7 @@ npx @evoapi/evo-nexus
 
 This downloads and runs the interactive setup wizard automatically.
 
-### Alternative: Manual Clone
+### Option C — Manual clone
 
 ```bash
 git clone --depth 1 https://github.com/EvolutionAPI/evo-nexus.git
@@ -3838,6 +3860,294 @@ See [Creating Routines](creating-routines.md) for details on the schedule and cu
 
 ---
 
+# Installing EvoNexus with Docker
+
+The fastest way to run EvoNexus on any machine — Linux, macOS (Intel or Apple Silicon), Windows with WSL2, or a bare VPS. Pulls official images from Docker Hub, no source checkout or build step required.
+
+## TL;DR
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+docker compose -f docker-compose.hub.yml up -d
+open http://localhost:8080
+```
+
+The setup wizard on first boot asks for a provider key (Anthropic, OpenAI or Codex). Everything else — integrations, Telegram, Stripe, Omie, Bling, Asaas, etc. — is configured through the UI.
+
+---
+
+## Prerequisites
+
+- **Docker Engine 24+** with Docker Compose v2. [Install on Mac / Windows / Linux](https://docs.docker.com/engine/install/).
+- **4 GB RAM minimum** (8 GB recommended — the Claude CLI and embedding models can be hungry).
+- **2 GB free disk** for images + a few hundred MB for data volumes.
+- An **Anthropic API key** (or OpenAI / ChatGPT Codex account) — you'll paste this into the wizard on first boot.
+
+No Node.js, Python, or any SDK needs to be installed on the host. The images ship everything.
+
+### Multi-arch — ARM64 works out of the box
+
+Images are published as multi-arch manifests (`linux/amd64` + `linux/arm64`), so:
+
+- **Apple Silicon** (M1/M2/M3 Macs) — pulls `arm64` natively, no Rosetta overhead.
+- **AWS Graviton**, **Oracle Cloud ARM free tier**, **Raspberry Pi 4/5** — pulls `arm64` natively.
+- **Traditional x86_64 servers** — pulls `amd64` as usual.
+
+You never pass `--platform`. Docker picks the right arch from the manifest list.
+
+---
+
+## Step 1 — Get the compose file
+
+Download the ready-to-run compose file. It pulls images from `evoapicloud/evo-nexus-{dashboard,runtime}` on Docker Hub — no git clone required.
+
+```bash
+curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.hub.yml
+```
+
+Open it — it's commented and self-explanatory. Key things to know:
+
+- **3 services**: `dashboard` (Flask + React + terminal), `telegram` (bot listener), `scheduler` (automated routines). Telegram and scheduler are optional — remove them from the file if you don't need them.
+- **Ports exposed**: `8080` (dashboard UI + API) and `32352` (terminal WebSocket).
+- **Volumes**: 6 named volumes that survive `docker compose down` and hold everything the UI configures.
+
+---
+
+## Step 2 — Start the stack
+
+```bash
+docker compose -f docker-compose.hub.yml up -d
+```
+
+First run downloads the images (~800 MB total, a few minutes depending on your connection). Subsequent boots are instant.
+
+Check that all 3 services are up:
+
+```bash
+docker compose -f docker-compose.hub.yml ps
+```
+
+You should see:
+
+```
+NAME                   STATUS
+evonexus-dashboard     Up (healthy)
+evonexus-telegram      Up
+evonexus-scheduler     Up
+```
+
+If the dashboard takes longer than 30 seconds to go healthy, check logs:
+
+```bash
+docker compose -f docker-compose.hub.yml logs -f dashboard
+```
+
+---
+
+## Step 3 — Open the UI and run the setup wizard
+
+Open **http://localhost:8080** in your browser. You'll see the first-boot wizard:
+
+1. **Create admin user** — username + password for the dashboard itself.
+2. **Pick a provider** — paste your Anthropic API key, OpenAI key, or click "Login with ChatGPT" for Codex OAuth.
+3. **Optional integrations** — Telegram bot token, Stripe, Omie, etc. Everything else is optional and can be added later.
+
+Once you save a provider key, the `telegram` and `scheduler` services (which were waiting in a 30s poll loop) pick it up and start working. No restart needed.
+
+---
+
+## Step 4 — Everyday commands
+
+| Action | Command |
+|---|---|
+| View logs | `docker compose -f docker-compose.hub.yml logs -f` |
+| Restart | `docker compose -f docker-compose.hub.yml restart` |
+| Stop | `docker compose -f docker-compose.hub.yml down` |
+| Stop + wipe data | `docker compose -f docker-compose.hub.yml down -v` ⚠️ |
+| Update to latest | See [Updating](#updating) below |
+
+---
+
+## Updating
+
+### Pull the latest stable image
+
+```bash
+docker compose -f docker-compose.hub.yml pull
+docker compose -f docker-compose.hub.yml up -d
+```
+
+Your data volumes are preserved — everything you configured through the UI stays intact.
+
+### Pin to a specific version
+
+Edit `docker-compose.hub.yml` and replace `:latest` with `:vX.Y.Z` (e.g. `:v0.30.4`). Available tags: https://hub.docker.com/r/evoapicloud/evo-nexus-dashboard/tags
+
+Rolling back is just bumping the tag down and running `pull && up -d`.
+
+---
+
+## Backup and restore
+
+Your configuration, workspace files, memory, and agent state live in 6 named volumes. To snapshot them all:
+
+```bash
+# Backup
+mkdir -p evonexus-backup
+for vol in config workspace dashboard_data memory adw_logs agent_memory; do
+  docker run --rm \
+    -v evonexus_${vol}:/src:ro \
+    -v "$PWD/evonexus-backup":/dst \
+    alpine tar czf /dst/${vol}.tgz -C /src .
+done
+
+# Restore on a fresh host
+for vol in config workspace dashboard_data memory adw_logs agent_memory; do
+  docker volume create evonexus_${vol}
+  docker run --rm \
+    -v evonexus_${vol}:/dst \
+    -v "$PWD/evonexus-backup":/src:ro \
+    alpine tar xzf /src/${vol}.tgz -C /dst
+done
+```
+
+---
+
+## Advanced: passing secrets via environment variables
+
+The default flow is "configure everything through the UI, which writes to a persisted `.env` inside the `evonexus_config` volume." Most users should stick with that.
+
+If you prefer to keep secrets out of the volume (for CI/CD, Vault, Doppler, or immutable infra), you can pass any env var directly in the compose file. They **take precedence** over the volume's `.env`:
+
+```yaml
+services:
+  dashboard:
+    image: evoapicloud/evo-nexus-dashboard:latest
+    environment:
+      - TZ=America/Sao_Paulo
+      - EVONEXUS_PORT=8080
+      # Bypass the UI — pass keys directly
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}      # read from shell or .env.compose
+      - EVONEXUS_SECRET_KEY=${EVONEXUS_SECRET_KEY}
+      - KNOWLEDGE_MASTER_KEY=${KNOWLEDGE_MASTER_KEY}
+    env_file:
+      - ./secrets.env   # or load from a file — this file is NOT inside the volume
+```
+
+Tradeoffs:
+
+- **Pro**: secrets live with the infrastructure, not the user-editable volume. Rotate by redeploying.
+- **Con**: the Providers page in the UI will still work (and will write to the volume's `.env`), but any value you pass via `environment:` wins. This can be confusing for non-technical users.
+
+For the absolutely purist flow, pass `REQUIRE_ANTHROPIC_KEY=0` on the telegram and scheduler services so they don't wait for a UI-saved key — they'll just use whatever is in `environment:`.
+
+---
+
+## Advanced: Docker Secrets
+
+Every env var also supports a `_FILE` counterpart. Point it at a file, and the entrypoint reads the content into the var at boot. This works natively with Docker Secrets in Swarm mode:
+
+```yaml
+services:
+  dashboard:
+    environment:
+      - ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_key
+    secrets:
+      - anthropic_key
+
+secrets:
+  anthropic_key:
+    external: true
+```
+
+Additionally, every file under `/run/secrets/` is auto-discovered: `/run/secrets/anthropic_api_key` → sets `ANTHROPIC_API_KEY` if it's not already set.
+
+---
+
+## Running on a VPS with a public domain
+
+For production on a single-host VPS (not a Swarm cluster), put a reverse proxy in front of `docker-compose.hub.yml`. The simplest path is Caddy:
+
+```yaml
+# Caddyfile next to docker-compose.hub.yml
+evonexus.example.com {
+    reverse_proxy /terminal/* localhost:32352
+    reverse_proxy localhost:8080
+}
+```
+
+Then `caddy run` and you have HTTPS with automatic Let's Encrypt certificates pointing at your EvoNexus stack.
+
+For Docker Swarm with Traefik, see [README.swarm.md](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) and [`evonexus.stack.yml`](https://github.com/EvolutionAPI/evo-nexus/blob/main/evonexus.stack.yml).
+
+---
+
+## Troubleshooting
+
+### Dashboard port 8080 is already in use
+
+Another service on your host is bound to 8080. Change the host port in the compose file:
+
+```yaml
+ports:
+  - "9090:8080"     # host 9090 → container 8080
+```
+
+Then open `http://localhost:9090`.
+
+### Telegram / scheduler logs say "waiting for ANTHROPIC_API_KEY"
+
+Expected. These services poll `.env` every 30s. Configure a provider key in **Dashboard → Providers** and they'll pick it up automatically — no restart needed.
+
+### Services keep restarting after `up -d`
+
+Check logs:
+
+```bash
+docker compose -f docker-compose.hub.yml logs --tail=50 <service>
+```
+
+99% of the time this is either (a) port conflict, (b) volume mount permission issue (rare, usually only on SELinux-enabled hosts — add `:Z` to volume mounts), or (c) disk full.
+
+### Fresh install doesn't show any agents / skills on `/agents` or `/skills`
+
+On a brand-new volume, the APIs return `{"error": "Setup required", "needs_setup": true}` until the wizard completes. Open http://localhost:8080 and complete the wizard first.
+
+### Want to see what's inside the running container
+
+```bash
+docker compose -f docker-compose.hub.yml exec dashboard bash
+```
+
+Useful paths inside the container:
+
+- `/workspace/config/.env` — everything the UI saves (ports, keys, integrations)
+- `/workspace/workspace/` — generated artifacts (reports, dashboards, daily logs)
+- `/workspace/memory/` — long-term memory the agents write
+- `/workspace/.claude/agent-memory/` — per-agent persistent state
+- `/workspace/ADWs/logs/` — routine execution logs (JSONL)
+
+---
+
+## Uninstall
+
+```bash
+docker compose -f docker-compose.hub.yml down -v
+```
+
+The `-v` flag also deletes the named volumes — **all your configuration and data is gone**. Skip the flag to keep volumes around for a future reinstall.
+
+---
+
+## See also
+
+- [Updating EvoNexus](./updating.md) — version bumps across all install methods
+- [README.swarm.md](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) — production Swarm / Portainer deployments with Traefik
+- [Environment variables reference](../reference/env-variables.md) — every variable the image recognizes
+
+
+---
+
 # Initial Setup and Onboarding
 
 The `initial-setup` skill gives you a guided tour of EvoNexus when you first start using it.
@@ -3961,21 +4271,32 @@ python app.py &
 
 ## Update via Docker (published images)
 
-Starting with **v0.30.2**, official images are published to Docker Hub under the `evoapicloud` namespace:
+Starting with **v0.30.2**, official multi-arch images (amd64 + arm64) are published to Docker Hub under the `evoapicloud` namespace:
 
 - `evoapicloud/evo-nexus-dashboard` — Flask + React + embedded terminal + Claude CLI
 - `evoapicloud/evo-nexus-runtime` — Node/Python runtime for the Telegram bot and the scheduler
 
 The images are public — no `docker login` required.
 
+### docker compose (single host, from Docker Hub)
+
+If you deployed with [`docker-compose.hub.yml`](https://github.com/EvolutionAPI/evo-nexus/blob/main/docker-compose.hub.yml) (the recommended flow documented in [Installing with Docker](./docker-install.md)):
+
+```bash
+docker compose -f docker-compose.hub.yml pull
+docker compose -f docker-compose.hub.yml up -d
+```
+
+Named volumes are preserved — all your configuration, providers, integrations, and memory stay intact.
+
 ### Docker Swarm / Portainer
 
 Bump the image tag in your stack (or leave `:latest` and force a redeploy). Example:
 
 ```bash
-docker service update --image evoapicloud/evo-nexus-dashboard:v0.30.2 evonexus_evonexus_dashboard
-docker service update --image evoapicloud/evo-nexus-runtime:v0.30.2   evonexus_evonexus_telegram
-docker service update --image evoapicloud/evo-nexus-runtime:v0.30.2   evonexus_evonexus_scheduler
+docker service update --image evoapicloud/evo-nexus-dashboard:v0.30.4 evonexus_evonexus_dashboard
+docker service update --image evoapicloud/evo-nexus-runtime:v0.30.4   evonexus_evonexus_telegram
+docker service update --image evoapicloud/evo-nexus-runtime:v0.30.4   evonexus_evonexus_scheduler
 ```
 
 See [`README.swarm.md`](https://github.com/EvolutionAPI/evo-nexus/blob/main/README.swarm.md) for the full Swarm / Portainer deployment guide and the `evonexus.stack.yml` template.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,18 +30,32 @@ mkdir -p "$CONFIG_DIR" \
          /workspace/.claude/agent-memory \
          /workspace/dashboard/data
 
+# --- 1b. Serialize first-boot bootstrap across services --------------------
+# The dashboard, telegram and scheduler services share /workspace/config on a
+# named volume. On first boot they race on "[ ! -f .env ] && cp .env.example"
+# (one succeeds, others crash with "File exists") and also on "grep -q KEY ||
+# echo >> .env" (two processes both see "not found" and append two different
+# keys, silently corrupting Flask sessions or Knowledge Base encryption).
+#
+# Serialize the whole bootstrap section with a flock on a lockfile inside the
+# shared volume — that way every process that mounts this volume takes turns
+# regardless of which container runs first.
+LOCK_FILE="$CONFIG_DIR/.bootstrap.lock"
+exec 200>"$LOCK_FILE"
+flock 200
+
 # --- 2. Bootstrap /workspace/config from image defaults (first boot only) --
 if [ -d "$DEFAULTS_DIR" ]; then
     if [ ! -f "$CONFIG_DIR/.env" ]; then
         if [ -f "$DEFAULTS_DIR/.env.example" ]; then
-            cp "$DEFAULTS_DIR/.env.example" "$CONFIG_DIR/.env"
+            cp -n "$DEFAULTS_DIR/.env.example" "$CONFIG_DIR/.env"
         else
             touch "$CONFIG_DIR/.env"
         fi
     fi
     for f in providers.example.json heartbeats.example.yaml; do
         if [ -f "$DEFAULTS_DIR/config/$f" ] && [ ! -f "$CONFIG_DIR/$f" ]; then
-            cp "$DEFAULTS_DIR/config/$f" "$CONFIG_DIR/$f"
+            cp -n "$DEFAULTS_DIR/config/$f" "$CONFIG_DIR/$f"
         fi
     done
 fi
@@ -80,6 +94,10 @@ if ! grep -q '^KNOWLEDGE_MASTER_KEY=' "$CONFIG_DIR/.env" 2>/dev/null; then
     fi
     unset _PYBIN _KEY
 fi
+
+# --- 3c. Release the bootstrap lock ----------------------------------------
+flock -u 200
+exec 200>&-
 
 # --- 4. Symlinks so the app finds files at the paths it expects ------------
 ln -sfn "$CONFIG_DIR/.env" /workspace/.env


### PR DESCRIPTION
## Summary

### 🐛 P0 Fix — race condition in first-boot bootstrap

When dashboard + telegram + scheduler share the same `/workspace/config` named volume (the canonical Docker / Swarm / Portainer deploy pattern), the 3 containers start in parallel and race on the bootstrap section of \`entrypoint.sh\`:

1. **Line 37** — \`[ ! -f .env ] && cp .env.example .env\` — one process wins, others crash with \`File exists\`. **Scheduler crashed visibly on every fresh deploy in v0.30.3.**
2. **Line 44** — same pattern for \`providers.json\` / \`heartbeats.yaml\`.
3. **Line 52-54** — \`grep -q EVONEXUS_SECRET_KEY || echo … >> .env\` — **two processes both see "not found" and append two different keys**. Flask then picks one at random on each request, invalidating sessions silently.
4. **Line 62-82** — same pattern for \`KNOWLEDGE_MASTER_KEY\` — **silently corrupts the Knowledge Base encryption**, losing all configured DB connections.

The \`cp\` was loud; \`grep || echo >>\` was silent. The silent ones are more dangerous.

### Fix
- Wrap the whole bootstrap section in \`flock\` on a lockfile inside the shared volume — serializes across all containers mounting the same volume.
- Add \`cp -n\` (no-clobber) as belt-and-suspenders for any code path that skips the lock.
- \`flock\` is part of \`util-linux\`, already in both base images (\`node:22-slim\` 2.38.1 and \`python:3.12-slim\` 2.41 — verified).

### Validated end-to-end
Bind-mounted the patched \`entrypoint.sh\` into the v0.30.3 images and booted all 3 services simultaneously:
- ✅ Scheduler survives (was making \`Exited (1)\` immediately)
- ✅ Telegram survives and enters the expected \`waiting for ANTHROPIC_API_KEY\` loop
- ✅ \`grep -c EVONEXUS_SECRET_KEY .env\` returns \`1\` (no duplicated keys)
- ✅ \`grep -c KNOWLEDGE_MASTER_KEY .env\` returns \`1\` (no duplicated keys)
- ✅ Dashboard \`healthy\` in ~15s

### 📚 Docs overhaul — Docker as a first-class install path

Users were asking for a complete Docker install experience. This PR adds:

- **\`docker-compose.hub.yml\`** — ready-to-run compose file. Pulls \`evoapicloud/evo-nexus-*\` from Docker Hub instead of building from source. \`depends_on: service_healthy\` orders the boot (dashboard first, then telegram/scheduler) — defense-in-depth on top of the flock fix.
- **\`docs/guides/docker-install.md\`** — full tutorial: prerequisites, one-command boot, wizard walkthrough, update flow, backup/restore recipes, **advanced section for users who prefer to pass secrets via environment/Docker Secrets** (answers the common "why can't I just use env vars?" question), running behind Caddy for public domains, troubleshooting table.
- **\`README.md\`** — Docker promoted to Method 1 in Quick Start. Prerequisites split into Docker vs CLI tracks.
- **\`docs/getting-started.md\`** — install-method chooser table at the top. Three clear paths: Docker / npx / manual clone.
- **\`docs/guides/updating.md\`** — new section documenting \`docker compose -f docker-compose.hub.yml pull && up -d\` and bumps Swarm example to \`:v0.30.4\`.

## Test plan
- [x] Reproduce the race on v0.30.3: scheduler \`Exited (1)\`, \`cp: File exists\`.
- [x] Apply patched \`entrypoint.sh\` via bind-mount, re-run — all 3 services stable, keys unique.
- [ ] After merge + release, smoke test the published multi-arch images end-to-end.
- [ ] \`docker compose -f docker-compose.hub.yml up -d\` on a clean host, all 3 services healthy without manual intervention.