### PR TITLE
feat(dashboard): redesign Agents page + chat with agent switcher

### DIFF
--- a/dashboard/frontend/src/components/AgentChat.tsx
+++ b/dashboard/frontend/src/components/AgentChat.tsx
@@ -904,7 +904,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
 
   return (
     <div
-      className="flex flex-col h-full bg-[#0C111D] relative"
+      className="flex flex-col h-full bg-[#080c14] relative"
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
@@ -949,29 +949,29 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
           </button>
           {showTicketPicker && (
             <div
-              className="absolute mt-1.5 left-0 w-72 rounded-lg border bg-[#161b22] shadow-xl z-50 max-h-80 overflow-y-auto"
+              className="absolute mt-1.5 left-0 w-72 rounded-lg border bg-[#11182a] shadow-xl z-50 max-h-80 overflow-y-auto"
               style={{ borderColor: '#21262d' }}
             >
-              <div className="px-3 py-2 border-b border-[#21262d] text-[10px] text-[#667085] uppercase tracking-wider">
+              <div className="px-3 py-2 border-b border-[#152030] text-[10px] text-[#5a6b7f] uppercase tracking-wider">
                 Attach to ticket
               </div>
               {ticketId && (
                 <button
                   onClick={() => bindTicket(null)}
-                  className="w-full text-left px-3 py-2 text-xs text-red-400 hover:bg-white/5 border-b border-[#21262d] flex items-center gap-2"
+                  className="w-full text-left px-3 py-2 text-xs text-red-400 hover:bg-white/5 border-b border-[#152030] flex items-center gap-2"
                 >
                   <X size={12} /> Detach current ticket
                 </button>
               )}
               <button
                 onClick={createAndBindTicket}
-                className="w-full text-left px-3 py-2 text-xs text-[#e6edf3] hover:bg-white/5 border-b border-[#21262d] flex items-center gap-2"
+                className="w-full text-left px-3 py-2 text-xs text-[#e6edf3] hover:bg-white/5 border-b border-[#152030] flex items-center gap-2"
                 style={{ color: accentColor }}
               >
                 <Plus size={12} /> Create new ticket
               </button>
               {tickets.length === 0 ? (
-                <div className="px-3 py-3 text-[11px] text-[#667085] italic">
+                <div className="px-3 py-3 text-[11px] text-[#5a6b7f] italic">
                   No open tickets for @{agent}
                 </div>
               ) : (
@@ -1047,7 +1047,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
             <p className="text-[#e6edf3] font-medium text-sm mb-1">
               Chat with @{agent}
             </p>
-            <p className="text-[#667085] text-xs max-w-[300px]">
+            <p className="text-[#5a6b7f] text-xs max-w-[300px]">
               Type a message below to start a conversation. The agent has access to your workspace tools.
             </p>
           </div>
@@ -1072,12 +1072,12 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                     }}
                     autoFocus
                     rows={Math.min(10, Math.max(2, editingText.split('\n').length))}
-                    className="w-full bg-transparent text-sm text-[#e6edf3] placeholder:text-[#667085] focus:outline-none resize-none"
+                    className="w-full bg-transparent text-sm text-[#e6edf3] placeholder-[#5a6b7f] focus:outline-none resize-none"
                   />
-                  <div className="flex justify-end gap-2 mt-2 pt-2 border-t border-[#21262d]">
+                  <div className="flex justify-end gap-2 mt-2 pt-2 border-t border-[#152030]">
                     <button
                       onClick={cancelEdit}
-                      className="px-3 py-1 rounded-md text-xs text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#21262d] transition-colors"
+                      className="px-3 py-1 rounded-md text-xs text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#11182a] transition-colors"
                     >
                       Cancel
                     </button>
@@ -1104,7 +1104,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                 <div className="flex items-center gap-0.5 opacity-0 group-hover/usermsg:opacity-100 transition-opacity mr-1">
                   <button
                     onClick={() => copyMessage(msg, i)}
-                    className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                    className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a]"
                     title={copiedIndex === i ? 'Copied' : 'Copy message'}
                   >
                     {copiedIndex === i ? <Check size={12} className="text-[#00FFA7]" /> : <Copy size={12} />}
@@ -1112,7 +1112,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                   {msg.uuid && status !== 'running' && !editingUuid && (
                     <button
                       onClick={() => startEdit(msg)}
-                      className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                      className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a]"
                       title="Edit message"
                     >
                       <Pencil size={12} />
@@ -1129,14 +1129,14 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                             key={fi}
                             src={f.previewUrl}
                             alt={f.name}
-                            className="w-24 h-24 object-cover rounded-xl border border-[#21262d]"
+                            className="w-24 h-24 object-cover rounded-xl border border-[#152030]"
                           />
                         ) : (
                           <div
                             key={fi}
-                            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[#21262d] bg-[#161b22]"
+                            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[#152030] bg-[#11182a]"
                           >
-                            <FileIcon size={12} className="text-[#667085]" />
+                            <FileIcon size={12} className="text-[#5a6b7f]" />
                             <span className="text-[11px] text-[#8b949e] truncate max-w-[140px]">{f.name}</span>
                           </div>
                         )
@@ -1145,7 +1145,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                   )}
                   {/* Text bubble */}
                   {(msg as any).text && (
-                    <div className="px-4 py-2.5 rounded-2xl rounded-br-md bg-[#1a2744] border border-[#21262d] text-[#e6edf3] text-sm leading-relaxed">
+                    <div className="px-4 py-2.5 rounded-2xl rounded-br-md bg-[#1a2744] border border-[#152030] text-[#e6edf3] text-sm leading-relaxed">
                       {(msg as any).text}
                     </div>
                   )}
@@ -1184,7 +1184,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                     <div className="opacity-0 group-hover/asstmsg:opacity-100 transition-opacity">
                       <button
                         onClick={() => copyMessage(msg, i)}
-                        className="flex items-center justify-center w-6 h-6 rounded-md text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d]"
+                        className="flex items-center justify-center w-6 h-6 rounded-md text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a]"
                         title={copiedIndex === i ? 'Copied' : 'Copy message'}
                       >
                         {copiedIndex === i ? <Check size={12} className="text-[#00FFA7]" /> : <Copy size={12} />}
@@ -1197,7 +1197,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
 
             {msg.role === 'system' && (
               <div className="text-center">
-                <span className="text-[11px] text-[#667085] bg-[#161b22] px-3 py-1 rounded-full border border-[#21262d]">
+                <span className="text-[11px] text-[#5a6b7f] bg-[#11182a] px-3 py-1 rounded-full border border-[#152030]">
                   {msg.text}
                 </span>
               </div>
@@ -1228,7 +1228,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
       </div>
 
       {/* Input area */}
-      <div className="flex-shrink-0 border-t border-[#21262d] bg-[#0d1117] px-4 py-3">
+      <div className="flex-shrink-0 border-t border-[#152030] bg-[#0b1018] px-4 py-3">
         <div className="max-w-3xl mx-auto space-y-2">
           {/* File previews */}
           {attachedFiles.length > 0 && (
@@ -1240,22 +1240,22 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                       <img
                         src={af.previewUrl}
                         alt={af.name}
-                        className="w-16 h-16 object-cover rounded-lg border border-[#21262d]"
+                        className="w-16 h-16 object-cover rounded-lg border border-[#152030]"
                       />
                       <button
                         onClick={() => removeFile(idx)}
-                        className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-[#161b22] border border-[#21262d] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity text-[#667085] hover:text-[#ef4444]"
+                        className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-[#11182a] border border-[#152030] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity text-[#5a6b7f] hover:text-[#ef4444]"
                       >
                         <X size={9} />
                       </button>
                     </div>
                   ) : (
-                    <div className="relative flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[#21262d] bg-[#161b22] pr-6">
-                      <FileIcon size={11} className="text-[#667085] flex-shrink-0" />
+                    <div className="relative flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-[#152030] bg-[#11182a] pr-6">
+                      <FileIcon size={11} className="text-[#5a6b7f] flex-shrink-0" />
                       <span className="text-[11px] text-[#8b949e] truncate max-w-[120px]">{af.name}</span>
                       <button
                         onClick={() => removeFile(idx)}
-                        className="absolute right-1.5 text-[#667085] hover:text-[#ef4444] transition-colors"
+                        className="absolute right-1.5 text-[#5a6b7f] hover:text-[#ef4444] transition-colors"
                       >
                         <X size={10} />
                       </button>
@@ -1271,14 +1271,14 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
             {/* Slash-command autocomplete popup */}
             {slashPopup.open && (
               <div
-                className="absolute left-0 right-0 rounded-xl border bg-[#161b22] shadow-xl overflow-y-auto z-50"
+                className="absolute left-0 right-0 rounded-xl border bg-[#11182a] shadow-xl overflow-y-auto z-50"
                 style={{ borderColor: '#21262d', maxHeight: '280px', bottom: 'calc(100% + 6px)' }}
               >
-                <div className="px-3 py-1.5 border-b border-[#21262d] text-[10px] text-[#667085] uppercase tracking-wider">
+                <div className="px-3 py-1.5 border-b border-[#152030] text-[10px] text-[#5a6b7f] uppercase tracking-wider">
                   Skills
                 </div>
                 {slashPopup.items.length === 0 ? (
-                  <div className="px-3 py-3 text-[11px] text-[#667085] italic">
+                  <div className="px-3 py-3 text-[11px] text-[#5a6b7f] italic">
                     No matching skills
                   </div>
                 ) : (
@@ -1299,7 +1299,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
                         /{skill.name}
                       </span>
                       {skill.description && (
-                        <span className="text-[#667085] truncate text-[11px]">
+                        <span className="text-[#5a6b7f] truncate text-[11px]">
                           {skill.description.slice(0, 80)}
                         </span>
                       )}
@@ -1311,13 +1311,13 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
 
           {/* Input row */}
           <div
-            className="flex items-end gap-2 rounded-xl border bg-[#161b22] px-3 py-2"
+            className="flex items-end gap-2 rounded-xl border bg-[#11182a] px-3 py-2"
             style={{ borderColor: '#21262d' }}
           >
             {/* Paperclip button */}
             <button
               onClick={() => fileInputRef.current?.click()}
-              className="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-lg text-[#667085] hover:text-[#e6edf3] hover:bg-[#21262d] transition-colors mb-0.5"
+              className="flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-lg text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a] transition-colors mb-0.5"
               title="Anexar arquivo"
             >
               <Paperclip size={14} />
@@ -1343,7 +1343,7 @@ export default function AgentChat({ agent, sessionId, accentColor = '#00FFA7', e
               onPaste={handlePaste}
               placeholder={`Message @${agent}...`}
               rows={1}
-              className="flex-1 resize-none bg-transparent text-sm text-[#e6edf3] placeholder:text-[#667085] focus:outline-none max-h-32 disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex-1 resize-none bg-transparent text-sm text-[#e6edf3] placeholder-[#5a6b7f] focus:outline-none max-h-32 disabled:cursor-not-allowed disabled:opacity-60"
               style={{ minHeight: '28px' }}
               onInput={(e) => {
                 const el = e.currentTarget
@@ -1415,7 +1415,7 @@ function TypingIndicator({ accentColor, isThinking }: { accentColor: string; isT
         ))}
       </div>
       <span
-        className="text-[10px] text-[#667085]"
+        className="text-[10px] text-[#5a6b7f]"
         style={{ animation: 'chat-pulse 2s ease-in-out infinite' }}
       >
         {isThinking ? 'Thinking...' : 'Typing...'}
@@ -1427,10 +1427,10 @@ function TypingIndicator({ accentColor, isThinking }: { accentColor: string; isT
 function AgentInputToggle({ parsedInput, rawInput }: { parsedInput: any; rawInput: string }) {
   const [showInput, setShowInput] = useState(false)
   return (
-    <div className="border-t border-[#21262d]/50">
+    <div className="border-t border-[#152030]/50">
       <button
         onClick={() => setShowInput(v => !v)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-[#667085] hover:text-[#8b949e] transition-colors w-full"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] text-[#5a6b7f] hover:text-[#8b949e] transition-colors w-full"
       >
         {showInput ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
         View input
@@ -1462,19 +1462,19 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
     const toolCount = subagentTools.length
 
     const getToolIcon = (toolName: string) => {
-      if (toolName === 'Bash') return <TermIcon size={11} className="text-[#667085] flex-shrink-0" />
-      if (toolName === 'Read') return <FileText size={11} className="text-[#667085] flex-shrink-0" />
-      if (toolName === 'Edit' || toolName === 'Write') return <Edit2 size={11} className="text-[#667085] flex-shrink-0" />
-      return <FileCode size={11} className="text-[#667085] flex-shrink-0" />
+      if (toolName === 'Bash') return <TermIcon size={11} className="text-[#5a6b7f] flex-shrink-0" />
+      if (toolName === 'Read') return <FileText size={11} className="text-[#5a6b7f] flex-shrink-0" />
+      if (toolName === 'Edit' || toolName === 'Write') return <Edit2 size={11} className="text-[#5a6b7f] flex-shrink-0" />
+      return <FileCode size={11} className="text-[#5a6b7f] flex-shrink-0" />
     }
 
     return (
-      <div className="border border-[#21262d] rounded-lg overflow-hidden">
+      <div className="border border-[#152030] rounded-lg overflow-hidden">
         <button
           onClick={() => setOpen(!open)}
-          className="flex items-center gap-2.5 w-full px-3 py-2.5 text-[12px] bg-[#161b22] hover:bg-[#1c2333] transition-colors"
+          className="flex items-center gap-2.5 w-full px-3 py-2.5 text-[12px] bg-[#11182a] hover:bg-[#1c2333] transition-colors"
         >
-          {open ? <ChevronDown size={12} className="text-[#667085]" /> : <ChevronRight size={12} className="text-[#667085]" />}
+          {open ? <ChevronDown size={12} className="text-[#5a6b7f]" /> : <ChevronRight size={12} className="text-[#5a6b7f]" />}
 
           {/* Subagent avatar */}
           {(() => {
@@ -1500,13 +1500,13 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
           <span className="ml-auto flex-shrink-0 flex items-center gap-2">
             {/* Tool count badge */}
             {toolCount > 0 && (
-              <span className="text-[10px] text-[#667085] tabular-nums">
+              <span className="text-[10px] text-[#5a6b7f] tabular-nums">
                 {toolCount} {toolCount === 1 ? 'tool' : 'tools'}
               </span>
             )}
             {/* Progress summary */}
             {isRunning && block.subagentSummary && (
-              <span className="text-[10px] text-[#667085] truncate max-w-[200px]" style={{ animation: 'chat-pulse 2s ease-in-out infinite' }}>
+              <span className="text-[10px] text-[#5a6b7f] truncate max-w-[200px]" style={{ animation: 'chat-pulse 2s ease-in-out infinite' }}>
                 {block.subagentSummary}
               </span>
             )}
@@ -1518,11 +1518,11 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
           </span>
         </button>
         {open && (
-          <div className="border-t border-[#21262d] bg-[#0d1117]">
+          <div className="border-t border-[#152030] bg-[#0b1018]">
             {/* Tool list */}
             <div className="max-h-80 overflow-y-auto">
               {subagentTools.length === 0 ? (
-                <div className="px-3 py-2 text-[11px] text-[#667085]">No tools yet</div>
+                <div className="px-3 py-2 text-[11px] text-[#5a6b7f]">No tools yet</div>
               ) : (
                 subagentTools.map((t, i) => {
                   let inputPreview = ''
@@ -1533,11 +1533,11 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
                     inputPreview = t.input.slice(0, 60)
                   }
                   return (
-                    <div key={t.toolUseId || i} className="flex items-center gap-2 px-3 py-1.5 text-[11px] border-t border-[#21262d]/50 first:border-t-0">
+                    <div key={t.toolUseId || i} className="flex items-center gap-2 px-3 py-1.5 text-[11px] border-t border-[#152030]/50 first:border-t-0">
                       {getToolIcon(t.toolName)}
                       <span className="text-[#8b949e] font-medium flex-shrink-0">{t.toolName}</span>
                       {inputPreview && (
-                        <span className="text-[#667085] truncate">{inputPreview}</span>
+                        <span className="text-[#5a6b7f] truncate">{inputPreview}</span>
                       )}
                     </div>
                   )
@@ -1558,15 +1558,15 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
     const completedCount = todos.filter(t => t.status === 'completed').length
 
     return (
-      <div className="border border-[#21262d] rounded-lg overflow-hidden">
+      <div className="border border-[#152030] rounded-lg overflow-hidden">
         <button
           onClick={() => setOpen(!open)}
-          className="flex items-center gap-2 w-full px-3 py-2 text-[12px] bg-[#161b22] hover:bg-[#1c2333] transition-colors"
+          className="flex items-center gap-2 w-full px-3 py-2 text-[12px] bg-[#11182a] hover:bg-[#1c2333] transition-colors"
         >
-          {open ? <ChevronDown size={12} className="text-[#667085]" /> : <ChevronRight size={12} className="text-[#667085]" />}
+          {open ? <ChevronDown size={12} className="text-[#5a6b7f]" /> : <ChevronRight size={12} className="text-[#5a6b7f]" />}
           <CheckCircle2 size={13} style={{ color: accentColor }} />
           <span className="font-medium text-[#e6edf3]">TodoWrite</span>
-          <span className="text-[#667085] text-[11px]">{completedCount}/{todos.length} done</span>
+          <span className="text-[#5a6b7f] text-[11px]">{completedCount}/{todos.length} done</span>
           <span className="ml-auto flex-shrink-0">
             {block.done ? (
               <CheckCircle2 size={13} className="text-[#22C55E]" />
@@ -1575,7 +1575,7 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
             )}
           </span>
         </button>
-        <div className="px-3 py-2 border-t border-[#21262d] bg-[#0d1117] space-y-1">
+        <div className="px-3 py-2 border-t border-[#152030] bg-[#0b1018] space-y-1">
           {todos.map((todo, i) => {
             const isPending = todo.status === 'pending'
             const isInProgress = todo.status === 'in_progress'
@@ -1609,16 +1609,16 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
     : ''
 
   return (
-    <div className="border border-[#21262d] rounded-lg overflow-hidden">
+    <div className="border border-[#152030] rounded-lg overflow-hidden">
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-[12px] bg-[#161b22] hover:bg-[#1c2333] transition-colors"
+        className="flex items-center gap-2 w-full px-3 py-2 text-[12px] bg-[#11182a] hover:bg-[#1c2333] transition-colors"
       >
-        {open ? <ChevronDown size={12} className="text-[#667085]" /> : <ChevronRight size={12} className="text-[#667085]" />}
+        {open ? <ChevronDown size={12} className="text-[#5a6b7f]" /> : <ChevronRight size={12} className="text-[#5a6b7f]" />}
         <FileCode size={13} style={{ color: accentColor }} />
         <span className="font-medium text-[#e6edf3]">{block.toolName}</span>
         {displayInfo && (
-          <span className="text-[#667085] truncate max-w-[300px] text-[11px] font-mono">{displayInfo}</span>
+          <span className="text-[#5a6b7f] truncate max-w-[300px] text-[11px] font-mono">{displayInfo}</span>
         )}
         <span className="ml-auto flex-shrink-0">
           {block.done ? (
@@ -1629,7 +1629,7 @@ function ToolCard({ block, accentColor }: { block: Extract<AssistantBlock, { typ
         </span>
       </button>
       {open && block.input && (
-        <div className="px-3 py-2 border-t border-[#21262d] bg-[#0d1117]">
+        <div className="px-3 py-2 border-t border-[#152030] bg-[#0b1018]">
           <pre className="text-[11px] text-[#8b949e] font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
             {parsedInput ? JSON.stringify(parsedInput, null, 2) : block.input}
           </pre>
@@ -1677,7 +1677,7 @@ function ApprovalCard({ req, accentColor, onAllow, onDeny }: ApprovalCardProps) 
           )}
         </div>
         {req.description && (
-          <p className="text-[10px] text-[#667085] truncate">{req.description}</p>
+          <p className="text-[10px] text-[#5a6b7f] truncate">{req.description}</p>
         )}
       </div>
       <div className="flex items-center gap-1.5 flex-shrink-0">

--- a/dashboard/frontend/src/components/chat/AgentSwitcher.tsx
+++ b/dashboard/frontend/src/components/chat/AgentSwitcher.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Search, ChevronDown, History, Bot, X } from 'lucide-react'
+import { api } from '../../lib/api'
+import { AgentAvatar } from '../AgentAvatar'
+
+interface AgentLite {
+  name: string
+  description?: string
+  custom?: boolean
+  locked?: boolean
+}
+
+interface AgentSwitcherProps {
+  currentAgent: string
+  accentColor?: string
+}
+
+const RECENT_KEY = 'evo:recent-agents'
+const MAX_RECENT = 6
+
+function getRecentAgents(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY)
+    if (!raw) return []
+    const data = JSON.parse(raw) as { name: string; ts: number }[]
+    return data.sort((a, b) => b.ts - a.ts).map(d => d.name).slice(0, MAX_RECENT)
+  } catch {
+    return []
+  }
+}
+
+function formatName(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+export default function AgentSwitcher({ currentAgent, accentColor = '#00FFA7' }: AgentSwitcherProps) {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [agents, setAgents] = useState<AgentLite[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [recents] = useState(getRecentAgents)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Lazy-load agents list when panel first opens
+  useEffect(() => {
+    if (!open || agents.length > 0) return
+    api.get('/agents')
+      .then((data) => setAgents(Array.isArray(data) ? data : []))
+      .catch(() => setAgents([]))
+  }, [open, agents.length])
+
+  const openPanel = useCallback(() => {
+    setQuery('')
+    setActiveIndex(0)
+    setOpen(true)
+    requestAnimationFrame(() => searchRef.current?.focus())
+  }, [])
+
+  const togglePanel = useCallback(() => {
+    setOpen((v) => {
+      if (!v) {
+        setQuery('')
+        setActiveIndex(0)
+        requestAnimationFrame(() => searchRef.current?.focus())
+      }
+      return !v
+    })
+  }, [])
+
+  // Cmd/Ctrl+K opens the switcher globally
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isMac = navigator.platform.toLowerCase().includes('mac')
+      const mod = isMac ? e.metaKey : e.ctrlKey
+      if (mod && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        if (open) setOpen(false)
+        else openPanel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, openPanel])
+
+  // Click outside to close
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (
+        panelRef.current && !panelRef.current.contains(target) &&
+        triggerRef.current && !triggerRef.current.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [open])
+
+  // Group: recents (filtered) at top, then all (filtered, alpha)
+  const items = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const accessible = agents.filter((a) => !a.locked && a.name !== currentAgent)
+    const matches = (a: AgentLite) => {
+      if (!q) return true
+      return a.name.toLowerCase().includes(q) || (a.description || '').toLowerCase().includes(q)
+    }
+
+    const recentSet = new Set(recents)
+    const recentMatches = recents
+      .map(name => accessible.find(a => a.name === name))
+      .filter((a): a is AgentLite => !!a && matches(a))
+
+    const otherMatches = accessible
+      .filter(a => !recentSet.has(a.name) && matches(a))
+      .sort((x, y) => x.name.localeCompare(y.name))
+
+    type Item = { type: 'recent' | 'all'; agent: AgentLite }
+    const flat: Item[] = [
+      ...recentMatches.map((a): Item => ({ type: 'recent', agent: a })),
+      ...otherMatches.map((a): Item => ({ type: 'all', agent: a })),
+    ]
+    return { recents: recentMatches, others: otherMatches, flat }
+  }, [agents, query, recents, currentAgent])
+
+  const select = (name: string) => {
+    setOpen(false)
+    if (name !== currentAgent) navigate(`/agents/${name}`)
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setOpen(false)
+      triggerRef.current?.focus()
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, items.flat.length - 1))
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+      return
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      const target = items.flat[activeIndex]
+      if (target) select(target.agent.name)
+    }
+  }
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (!open) return
+    const list = listRef.current
+    if (!list) return
+    const active = list.querySelector<HTMLElement>(`[data-idx="${activeIndex}"]`)
+    if (active) active.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex, open])
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        onClick={togglePanel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={`Switch agent (current: ${formatName(currentAgent)})`}
+        className="group flex items-center gap-3 rounded-lg px-2 py-1.5 -mx-2 transition-colors hover:bg-[#152030] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
+      >
+        <div
+          className="rounded-full flex-shrink-0"
+          style={{ padding: 2, background: `${accentColor}40` }}
+        >
+          <AgentAvatar name={currentAgent} size={44} />
+        </div>
+        <div className="flex flex-col min-w-0 text-left">
+          <span className="text-[14px] font-semibold text-[#e6edf3] tracking-tight truncate flex items-center gap-1.5">
+            {formatName(currentAgent)}
+            <ChevronDown
+              size={14}
+              className="text-[#5a6b7f] transition-transform group-hover:text-[#e6edf3]"
+              style={{ transform: open ? 'rotate(180deg)' : 'none' }}
+            />
+          </span>
+          <span className="text-[10px] uppercase tracking-[0.12em] text-[#5a6b7f] hidden sm:inline">
+            Switch agent · ⌘K
+          </span>
+        </div>
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="Agent switcher"
+          className="absolute left-0 top-full mt-2 w-[360px] max-w-[calc(100vw-2rem)] rounded-xl border border-[#152030] bg-[#0b1018] shadow-[0_12px_50px_rgba(0,0,0,0.5)] z-50 flex flex-col overflow-hidden"
+          onKeyDown={onKeyDown}
+        >
+          {/* Search */}
+          <div className="flex items-center gap-2 px-3 py-2.5 border-b border-[#152030]">
+            <Search size={14} className="text-[#5a6b7f] flex-shrink-0" aria-hidden />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e) => { setQuery(e.target.value); setActiveIndex(0) }}
+              placeholder="Search agents…"
+              aria-label="Search agents"
+              className="flex-1 min-w-0 bg-transparent text-[13px] text-[#e6edf3] placeholder:text-[#5a6b7f] focus:outline-none"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => { setQuery(''); searchRef.current?.focus() }}
+                aria-label="Clear search"
+                className="p-0.5 rounded text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#152030] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
+              >
+                <X size={12} />
+              </button>
+            )}
+            <kbd className="hidden sm:inline-block ml-1 text-[9px] font-mono px-1.5 py-0.5 rounded bg-[#080c14] border border-[#152030] text-[#5a6b7f]">
+              esc
+            </kbd>
+          </div>
+
+          {/* List */}
+          <div ref={listRef} role="listbox" aria-label="Agents" className="flex-1 overflow-y-auto max-h-[420px] py-1">
+            {agents.length === 0 ? (
+              <div className="px-4 py-6 text-center text-[12px] text-[#5a6b7f]">Loading agents…</div>
+            ) : items.flat.length === 0 ? (
+              <div className="px-4 py-6 text-center text-[12px] text-[#5a6b7f]">No matches.</div>
+            ) : (
+              <>
+                {items.recents.length > 0 && (
+                  <div>
+                    <div className="px-3 pt-2 pb-1 flex items-center gap-1.5">
+                      <History size={10} className="text-[#5a6b7f]" aria-hidden />
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#5a6b7f]">
+                        Recent
+                      </span>
+                    </div>
+                    {items.recents.map((a, i) => (
+                      <SwitcherRow
+                        key={a.name}
+                        agent={a}
+                        idx={i}
+                        active={i === activeIndex}
+                        onMouseEnter={() => setActiveIndex(i)}
+                        onClick={() => select(a.name)}
+                      />
+                    ))}
+                  </div>
+                )}
+                {items.others.length > 0 && (
+                  <div>
+                    <div className="px-3 pt-3 pb-1 flex items-center gap-1.5">
+                      <Bot size={10} className="text-[#5a6b7f]" aria-hidden />
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#5a6b7f]">
+                        All agents
+                      </span>
+                    </div>
+                    {items.others.map((a, i) => {
+                      const idx = items.recents.length + i
+                      return (
+                        <SwitcherRow
+                          key={a.name}
+                          agent={a}
+                          idx={idx}
+                          active={idx === activeIndex}
+                          onMouseEnter={() => setActiveIndex(idx)}
+                          onClick={() => select(a.name)}
+                        />
+                      )
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Footer hints */}
+          <div className="flex items-center justify-between gap-2 px-3 py-2 border-t border-[#152030] text-[10px] text-[#5a6b7f]">
+            <div className="flex items-center gap-2">
+              <kbd className="font-mono px-1.5 py-0.5 rounded bg-[#080c14] border border-[#152030]">↑↓</kbd>
+              <span>navigate</span>
+              <kbd className="font-mono px-1.5 py-0.5 rounded bg-[#080c14] border border-[#152030]">↵</kbd>
+              <span>open</span>
+            </div>
+            <span>{items.flat.length} {items.flat.length === 1 ? 'agent' : 'agents'}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface RowProps {
+  agent: AgentLite
+  idx: number
+  active: boolean
+  onMouseEnter: () => void
+  onClick: () => void
+}
+
+function SwitcherRow({ agent, idx, active, onMouseEnter, onClick }: RowProps) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      data-idx={idx}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors focus:outline-none ${
+        active ? 'bg-[#00FFA7]/10' : 'hover:bg-[#152030]'
+      }`}
+    >
+      <AgentAvatar name={agent.name} size={28} />
+      <div className="flex-1 min-w-0">
+        <div className={`text-[12.5px] font-medium truncate ${active ? 'text-[#00FFA7]' : 'text-[#e6edf3]'}`}>
+          {formatName(agent.name)}
+        </div>
+        {agent.description && (
+          <div className="text-[10.5px] text-[#5a6b7f] truncate">{agent.description}</div>
+        )}
+      </div>
+      {agent.custom && (
+        <span className="text-[9px] uppercase tracking-wider text-[#C084FC] flex-shrink-0">custom</span>
+      )}
+    </button>
+  )
+}

--- a/dashboard/frontend/src/components/ui/Badge.tsx
+++ b/dashboard/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,41 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+type Tone = 'neutral' | 'accent' | 'danger' | 'warning' | 'muted'
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: Tone
+  dot?: boolean
+  children: ReactNode
+}
+
+const tones: Record<Tone, string> = {
+  neutral: 'bg-[#161b22] border border-[#21262d] text-[#e6edf3]',
+  accent:  'bg-[#00FFA7]/10 border border-[#00FFA7]/30 text-[#00FFA7]',
+  danger:  'bg-[#3a1515]/40 border border-[#5a2020]/60 text-[#f87171]',
+  warning: 'bg-[#3a2c0a]/40 border border-[#5a4520]/60 text-[#f59e0b]',
+  muted:   'bg-[#0f1520] border border-[#1e2a3a] text-[#5a6b7f]',
+}
+
+const dotColor: Record<Tone, string> = {
+  neutral: 'bg-[#667085]',
+  accent:  'bg-[#00FFA7]',
+  danger:  'bg-[#ef4444]',
+  warning: 'bg-[#f59e0b]',
+  muted:   'bg-[#3d4f65]',
+}
+
+export function Badge({ tone = 'neutral', dot = false, className = '', children, ...rest }: BadgeProps) {
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium',
+        tones[tone],
+        className,
+      ].join(' ')}
+      {...rest}
+    >
+      {dot && <span aria-hidden className={`w-1.5 h-1.5 rounded-full ${dotColor[tone]}`} />}
+      {children}
+    </span>
+  )
+}

--- a/dashboard/frontend/src/components/ui/Button.tsx
+++ b/dashboard/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,71 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type Size = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant
+  size?: Size
+  fullWidth?: boolean
+  leftIcon?: ReactNode
+  rightIcon?: ReactNode
+  loading?: boolean
+  children?: ReactNode
+}
+
+const variants: Record<Variant, string> = {
+  primary:
+    'bg-[#00FFA7] text-[#080c14] hover:bg-[#00e69a] active:bg-[#00cc88] focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40',
+  secondary:
+    'bg-[#0f1520] border border-[#1e2a3a] text-[#e2e8f0] hover:border-[#2e3a4a] hover:bg-[#152030] focus-visible:ring-2 focus-visible:ring-[#00FFA7]/30',
+  ghost:
+    'text-[#5a6b7f] hover:text-[#e2e8f0] hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-[#00FFA7]/30',
+  danger:
+    'bg-[#3a1515] border border-[#5a2020] text-[#f87171] hover:bg-[#4a1c1c] focus-visible:ring-2 focus-visible:ring-red-500/40',
+}
+
+const sizes: Record<Size, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-4 py-2.5 text-sm',
+  lg: 'px-5 py-3 text-sm',
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  leftIcon,
+  rightIcon,
+  loading = false,
+  className = '',
+  children,
+  disabled,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled || loading}
+      className={[
+        'inline-flex items-center justify-center gap-2 rounded-lg font-semibold',
+        'transition-colors duration-200 disabled:opacity-40 disabled:cursor-not-allowed',
+        'focus:outline-none focus-visible:ring-offset-1 focus-visible:ring-offset-[#080c14]',
+        variants[variant],
+        sizes[size],
+        fullWidth ? 'w-full' : '',
+        className,
+      ].join(' ')}
+      {...rest}
+    >
+      {loading ? (
+        <span
+          aria-hidden
+          className="w-4 h-4 border-2 border-current/30 border-t-current rounded-full animate-spin"
+        />
+      ) : (
+        leftIcon
+      )}
+      {children}
+      {!loading && rightIcon}
+    </button>
+  )
+}

--- a/dashboard/frontend/src/components/ui/Card.tsx
+++ b/dashboard/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,44 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+type Variant = 'premium' | 'default' | 'flat'
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: Variant
+  interactive?: boolean
+  accent?: boolean
+  children: ReactNode
+}
+
+const base: Record<Variant, string> = {
+  premium:
+    'rounded-xl border border-[#152030] bg-[#0b1018] shadow-[0_4px_40px_rgba(0,0,0,0.4)]',
+  default:
+    'rounded-2xl border border-[#21262d] bg-[#161b22]',
+  flat:
+    'rounded-xl border border-[#1e2a3a] bg-[#0f1520]',
+}
+
+export function Card({
+  variant = 'default',
+  interactive = false,
+  accent = false,
+  className = '',
+  children,
+  ...rest
+}: CardProps) {
+  const interactiveClasses = interactive
+    ? 'transition-all duration-300 hover:border-[#00FFA7]/40 hover:shadow-[0_0_24px_rgba(0,255,167,0.06)]'
+    : ''
+
+  return (
+    <div className={`relative ${base[variant]} ${interactiveClasses} ${className}`} {...rest}>
+      {accent && (
+        <span
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#00FFA7]/30 to-transparent rounded-t-2xl"
+        />
+      )}
+      {children}
+    </div>
+  )
+}

--- a/dashboard/frontend/src/components/ui/Input.tsx
+++ b/dashboard/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react'
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  leftIcon?: ReactNode
+  rightSlot?: ReactNode
+  invalid?: boolean
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { leftIcon, rightSlot, invalid = false, className = '', ...rest },
+  ref,
+) {
+  const borderClass = invalid
+    ? 'border-[#5a2020] focus:border-red-500/60 focus:ring-1 focus:ring-red-500/20'
+    : 'border-[#1e2a3a] focus:border-[#00FFA7]/60 focus:ring-1 focus:ring-[#00FFA7]/20'
+
+  if (!leftIcon && !rightSlot) {
+    return (
+      <input
+        ref={ref}
+        className={[
+          'w-full px-4 py-3 rounded-lg bg-[#0f1520] border text-[#e2e8f0] placeholder-[#3d4f65]',
+          'text-sm transition-colors duration-200 focus:outline-none',
+          borderClass,
+          className,
+        ].join(' ')}
+        {...rest}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={[
+        'flex items-center gap-2 px-3 rounded-lg bg-[#0f1520] border transition-colors duration-200',
+        'focus-within:ring-1',
+        invalid
+          ? 'border-[#5a2020] focus-within:border-red-500/60 focus-within:ring-red-500/20'
+          : 'border-[#1e2a3a] focus-within:border-[#00FFA7]/60 focus-within:ring-[#00FFA7]/20',
+        className,
+      ].join(' ')}
+    >
+      {leftIcon && <span className="text-[#5a6b7f] flex-shrink-0">{leftIcon}</span>}
+      <input
+        ref={ref}
+        className="flex-1 min-w-0 bg-transparent py-2.5 text-sm text-[#e2e8f0] placeholder-[#3d4f65] focus:outline-none"
+        {...rest}
+      />
+      {rightSlot && <span className="flex-shrink-0">{rightSlot}</span>}
+    </div>
+  )
+})

--- a/dashboard/frontend/src/components/ui/Label.tsx
+++ b/dashboard/frontend/src/components/ui/Label.tsx
@@ -1,0 +1,16 @@
+import type { LabelHTMLAttributes, ReactNode } from 'react'
+
+interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  children: ReactNode
+}
+
+export function Label({ className = '', children, ...rest }: LabelProps) {
+  return (
+    <label
+      className={`block text-[11px] font-semibold text-[#5a6b7f] mb-1.5 tracking-[0.08em] uppercase ${className}`}
+      {...rest}
+    >
+      {children}
+    </label>
+  )
+}

--- a/dashboard/frontend/src/components/ui/MeshBackground.tsx
+++ b/dashboard/frontend/src/components/ui/MeshBackground.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from 'react'
+
+interface MeshBackgroundProps {
+  density?: number
+  maxParticles?: number
+  maxDistance?: number
+  particleColor?: string
+  lineColor?: string
+  className?: string
+  zIndex?: number
+}
+
+export function MeshBackground({
+  density = 18000,
+  maxParticles = 80,
+  maxDistance = 150,
+  particleColor = 'rgba(0, 255, 167, 0.25)',
+  lineColor = '0, 255, 167',
+  className = 'fixed inset-0 pointer-events-none',
+  zIndex = 0,
+}: MeshBackgroundProps) {
+  const ref = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduced) return
+
+    const canvas = ref.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    let animId = 0
+    let particles: { x: number; y: number; vx: number; vy: number }[] = []
+
+    const resize = () => {
+      canvas.width = window.innerWidth
+      canvas.height = window.innerHeight
+    }
+
+    const init = () => {
+      resize()
+      const count = Math.floor((canvas.width * canvas.height) / density)
+      particles = Array.from({ length: Math.min(count, maxParticles) }, () => ({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        vx: (Math.random() - 0.5) * 0.3,
+        vy: (Math.random() - 0.5) * 0.3,
+      }))
+    }
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      for (let i = 0; i < particles.length; i++) {
+        const p = particles[i]
+        p.x += p.vx
+        p.y += p.vy
+        if (p.x < 0 || p.x > canvas.width) p.vx *= -1
+        if (p.y < 0 || p.y > canvas.height) p.vy *= -1
+
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2)
+        ctx.fillStyle = particleColor
+        ctx.fill()
+
+        for (let j = i + 1; j < particles.length; j++) {
+          const q = particles[j]
+          const dx = p.x - q.x
+          const dy = p.y - q.y
+          const dist = Math.sqrt(dx * dx + dy * dy)
+          if (dist < maxDistance) {
+            ctx.beginPath()
+            ctx.moveTo(p.x, p.y)
+            ctx.lineTo(q.x, q.y)
+            ctx.strokeStyle = `rgba(${lineColor}, ${0.06 * (1 - dist / maxDistance)})`
+            ctx.lineWidth = 0.5
+            ctx.stroke()
+          }
+        }
+      }
+      animId = requestAnimationFrame(draw)
+    }
+
+    init()
+    draw()
+    window.addEventListener('resize', init)
+    return () => {
+      cancelAnimationFrame(animId)
+      window.removeEventListener('resize', init)
+    }
+  }, [density, maxParticles, maxDistance, particleColor, lineColor])
+
+  return <canvas ref={ref} aria-hidden className={className} style={{ zIndex }} />
+}

--- a/dashboard/frontend/src/components/ui/Spinner.tsx
+++ b/dashboard/frontend/src/components/ui/Spinner.tsx
@@ -1,0 +1,15 @@
+interface SpinnerProps {
+  size?: number
+  className?: string
+}
+
+export function Spinner({ size = 20, className = '' }: SpinnerProps) {
+  return (
+    <span
+      role="status"
+      aria-label="Loading"
+      className={`inline-block border-2 border-[#00FFA7]/20 border-t-[#00FFA7] rounded-full animate-spin ${className}`}
+      style={{ width: size, height: size }}
+    />
+  )
+}

--- a/dashboard/frontend/src/components/ui/index.ts
+++ b/dashboard/frontend/src/components/ui/index.ts
@@ -1,0 +1,7 @@
+export { Card } from './Card'
+export { Button } from './Button'
+export { Input } from './Input'
+export { Label } from './Label'
+export { Badge } from './Badge'
+export { Spinner } from './Spinner'
+export { MeshBackground } from './MeshBackground'

--- a/dashboard/frontend/src/pages/AgentDetail.tsx
+++ b/dashboard/frontend/src/pages/AgentDetail.tsx
@@ -6,9 +6,9 @@ import Markdown from '../components/Markdown'
 import AgentTerminal from '../components/AgentTerminal'
 import AgentChat from '../components/AgentChat'
 import ChatSessionList, { type ChatSession } from '../components/ChatSessionList'
+import AgentSwitcher from '../components/chat/AgentSwitcher'
 import { getAgentMeta } from '../lib/agent-meta'
 import { trackAgentVisit } from './Agents'
-import { AgentAvatar } from '../components/AgentAvatar'
 import { useAuth } from '../context/AuthContext'
 import { useNotificationBadge } from '../hooks/useNotificationBadge'
 
@@ -341,19 +341,19 @@ export default function AgentDetail() {
   // Check agent access before rendering anything
   if (!hasAgentAccess(name)) {
     return (
-      <div className="h-full w-full flex flex-col items-center justify-center bg-[#0C111D] gap-4">
-        <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-[#161b22] border border-[#21262d]">
-          <Lock size={28} className="text-[#667085]" />
+      <div className="h-full w-full flex flex-col items-center justify-center bg-[#080c14] gap-4">
+        <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-[#0b1018] border border-[#152030]">
+          <Lock size={28} className="text-[#5a6b7f]" aria-hidden />
         </div>
         <div className="text-center">
           <p className="text-[#e6edf3] font-semibold text-base mb-1">Acesso restrito</p>
-          <p className="text-[#667085] text-sm">Você não tem permissão para acessar este agente.</p>
+          <p className="text-[#5a6b7f] text-sm">Você não tem permissão para acessar este agente.</p>
         </div>
         <Link
           to="/agents"
-          className="mt-2 text-[11px] uppercase tracking-[0.12em] text-[#00FFA7] hover:underline"
+          className="mt-2 inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.12em] text-[#00FFA7] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded px-2 py-1"
         >
-          ← Agentes
+          <ArrowLeft size={11} aria-hidden /> Agentes
         </Link>
       </div>
     )
@@ -364,18 +364,18 @@ export default function AgentDetail() {
 
   if (loading) {
     return (
-      <div className="h-full w-full flex items-center justify-center bg-[#0C111D]">
-        <div className="text-[#667085] text-xs uppercase tracking-[0.12em]">loading agent…</div>
+      <div className="h-full w-full flex items-center justify-center bg-[#080c14]">
+        <div className="text-[#5a6b7f] text-xs uppercase tracking-[0.12em]">loading agent…</div>
       </div>
     )
   }
 
   if (!content) {
     return (
-      <div className="h-full w-full flex flex-col items-center justify-center bg-[#0C111D] gap-3">
-        <p className="text-[#667085] text-sm">Agent not found</p>
-        <Link to="/agents" className="text-[11px] uppercase tracking-[0.12em] text-[#00FFA7] hover:underline">
-          ← Agents
+      <div className="h-full w-full flex flex-col items-center justify-center bg-[#080c14] gap-3">
+        <p className="text-[#8b949e] text-sm">Agent not found</p>
+        <Link to="/agents" className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.12em] text-[#00FFA7] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded px-2 py-1">
+          <ArrowLeft size={11} aria-hidden /> Agents
         </Link>
       </div>
     )
@@ -385,52 +385,42 @@ export default function AgentDetail() {
   const profileLead = extractProfileLead(content)
 
   return (
-    <div className="flex h-full w-full flex-col bg-[#0C111D]">
+    <div className="flex h-full w-full flex-col bg-[#080c14]">
       {/* ── HERO STRIP ─────────────────────────────────────────────── */}
-      <header className="flex-shrink-0 h-20 flex items-center px-4 lg:px-6 gap-4 border-b border-[#21262d] bg-[#0d1117]">
+      <header className="flex-shrink-0 h-[72px] flex items-center px-4 lg:px-6 gap-4 border-b border-[#152030] bg-[#0b1018]">
         <Link
           to="/agents"
-          className="flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-[#667085] hover:text-[#e6edf3] transition-colors"
+          aria-label="Back to agents"
+          className="group flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-[#5a6b7f] hover:text-[#e6edf3] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded px-1.5 py-1"
         >
-          <ArrowLeft size={12} />
+          <ArrowLeft size={12} className="transition-transform group-hover:-translate-x-0.5" aria-hidden />
           Agents
         </Link>
 
-        <span className="text-[#21262d]">·</span>
+        <span aria-hidden className="text-[#152030]">|</span>
 
-        {/* Avatar */}
-        <div
-          className="rounded-full flex-shrink-0"
-          style={{ padding: 2, background: `${agentColor}40` }}
-        >
-          <AgentAvatar name={name} size={60} />
-        </div>
+        {/* Agent switcher (clickable avatar + name) */}
+        <AgentSwitcher currentAgent={name} accentColor={agentColor} />
 
-        <div className="flex flex-col gap-0.5 min-w-0">
-          <h1 className="text-[16px] font-semibold text-[#e6edf3] tracking-tight truncate">
-            {formatName(name)}
-          </h1>
+        {/* Right side */}
+        <div className="ml-auto flex items-center gap-3">
           <code
-            className="font-mono text-[11px] tracking-tight"
+            className="hidden md:inline font-mono text-[11px] tracking-tight px-2 py-0.5 rounded bg-[#080c14] border border-[#152030]"
             style={{ color: agentColor }}
           >
             {meta.command}
           </code>
-        </div>
-
-        {/* Memory count — right aligned */}
-        <div className="ml-auto flex items-center gap-4">
-          <span className="hidden sm:inline text-[10px] uppercase tracking-[0.12em] text-[#667085]">
+          <span className="hidden sm:inline text-[10px] uppercase tracking-[0.12em] text-[#5a6b7f]">
             {memories.length} {memories.length === 1 ? 'memory' : 'memories'}
           </span>
 
           {/* Mobile drawer toggle */}
           <button
             onClick={() => setRailOpen(true)}
-            className="lg:hidden flex h-8 w-8 items-center justify-center rounded-md border border-[#21262d] text-[#8b949e] hover:text-[#e6edf3] hover:border-[#30363d]"
+            className="lg:hidden flex h-8 w-8 items-center justify-center rounded-md border border-[#152030] text-[#8b949e] hover:text-[#e6edf3] hover:border-[#1e2d3d] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
             aria-label="Open agent info"
           >
-            <PanelLeft size={14} />
+            <PanelLeft size={14} aria-hidden />
           </button>
         </div>
       </header>
@@ -438,7 +428,7 @@ export default function AgentDetail() {
       {/* ── BODY ───────────────────────────────────────────────────── */}
       <div className="flex flex-1 min-h-0 relative">
         {/* Info rail — desktop */}
-        <aside className="hidden lg:flex flex-col w-[320px] flex-shrink-0 border-r border-[#21262d] bg-[#0d1117]">
+        <aside className="hidden lg:flex flex-col w-[320px] flex-shrink-0 border-r border-[#152030] bg-[#0b1018]">
           <InfoRail
             tab={tab}
             setTab={setTab}
@@ -468,19 +458,19 @@ export default function AgentDetail() {
             onClick={() => setRailOpen(false)}
           >
             <aside
-              className="absolute top-14 left-0 bottom-0 w-[85vw] max-w-[340px] border-r border-[#21262d] bg-[#0d1117] flex flex-col"
+              className="absolute top-14 left-0 bottom-0 w-[85vw] max-w-[340px] border-r border-[#152030] bg-[#0b1018] flex flex-col animate-slide-in-left"
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex items-center justify-between px-4 h-10 border-b border-[#21262d]">
-                <span className="text-[10px] uppercase tracking-[0.12em] text-[#667085]">
+              <div className="flex items-center justify-between px-4 h-10 border-b border-[#152030]">
+                <span className="text-[10px] uppercase tracking-[0.12em] text-[#5a6b7f]">
                   {formatName(name)}
                 </span>
                 <button
                   onClick={() => setRailOpen(false)}
-                  className="text-[#8b949e] hover:text-[#e6edf3]"
+                  className="text-[#8b949e] hover:text-[#e6edf3] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded p-1"
                   aria-label="Close"
                 >
-                  <X size={14} />
+                  <X size={14} aria-hidden />
                 </button>
               </div>
               <InfoRail
@@ -508,9 +498,10 @@ export default function AgentDetail() {
         )}
 
         {/* Terminal / Chat stage */}
-        <section className="flex-1 min-w-0 relative bg-[#0C111D] overflow-hidden flex flex-col">
+        <section className="flex-1 min-w-0 relative bg-[#080c14] overflow-hidden flex flex-col">
           {/* Ambient glow */}
           <div
+            aria-hidden
             className="pointer-events-none absolute top-0 right-0 h-[400px] w-[400px] blur-3xl"
             style={{
               background: `radial-gradient(circle, ${agentColor} 0%, transparent 60%)`,
@@ -519,68 +510,73 @@ export default function AgentDetail() {
           />
 
           {/* View mode bar + terminal tabs */}
-          <div className="relative z-10 flex items-center flex-shrink-0 h-9 border-b border-[#21262d] bg-[#0d1117]">
-            {/* View mode toggle */}
-            <div className="flex items-center border-r border-[#21262d] h-full">
+          <div role="tablist" aria-label="View mode" className="relative z-10 flex items-center flex-shrink-0 h-9 border-b border-[#152030] bg-[#0b1018]">
+            <div className="flex items-center border-r border-[#152030] h-full">
               <button
+                role="tab"
+                aria-selected={viewMode === 'chat'}
                 onClick={() => { setViewMode('chat'); localStorage.setItem('evo:agent-view-mode', 'chat') }}
-                className={`flex items-center gap-1.5 px-3 h-full text-[11px] transition-colors ${
+                className={`flex items-center gap-1.5 px-3 h-full text-[11px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#00FFA7]/40 ${
                   viewMode === 'chat'
-                    ? 'text-[#e6edf3] bg-[#0C111D]'
-                    : 'text-[#667085] hover:text-[#e6edf3] hover:bg-[#161b22]'
+                    ? 'text-[#e6edf3] bg-[#080c14]'
+                    : 'text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a]'
                 }`}
               >
-                <MessageSquare size={12} style={{ color: viewMode === 'chat' ? agentColor : undefined }} />
+                <MessageSquare size={12} aria-hidden style={{ color: viewMode === 'chat' ? agentColor : undefined }} />
                 Chat
               </button>
               <button
+                role="tab"
+                aria-selected={viewMode === 'terminal'}
                 onClick={() => { setViewMode('terminal'); localStorage.setItem('evo:agent-view-mode', 'terminal') }}
-                className={`flex items-center gap-1.5 px-3 h-full text-[11px] transition-colors ${
+                className={`flex items-center gap-1.5 px-3 h-full text-[11px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#00FFA7]/40 ${
                   viewMode === 'terminal'
-                    ? 'text-[#e6edf3] bg-[#0C111D]'
-                    : 'text-[#667085] hover:text-[#e6edf3] hover:bg-[#161b22]'
+                    ? 'text-[#e6edf3] bg-[#080c14]'
+                    : 'text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a]'
                 }`}
               >
-                <TerminalIcon size={12} style={{ color: viewMode === 'terminal' ? agentColor : undefined }} />
+                <TerminalIcon size={12} aria-hidden style={{ color: viewMode === 'terminal' ? agentColor : undefined }} />
                 Terminal
               </button>
             </div>
 
-            {/* Terminal tabs — only in terminal mode with multiple tabs */}
             {viewMode === 'terminal' && (
               <div className="flex items-center flex-1 h-full overflow-x-auto">
                 {termTabs.length > 1 && termTabs.map((tt) => (
                   <div
                     key={tt.id}
-                    className={`group flex items-center gap-2 px-3 h-full text-[11px] cursor-pointer border-r border-[#21262d] transition-colors ${
+                    className={`group flex items-center gap-2 px-3 h-full text-[11px] cursor-pointer border-r border-[#152030] transition-colors ${
                       activeTermTab === tt.id
-                        ? 'bg-[#0C111D] text-[#e6edf3]'
-                        : 'text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#161b22]'
+                        ? 'bg-[#080c14] text-[#e6edf3]'
+                        : 'text-[#8b949e] hover:text-[#e6edf3] hover:bg-[#11182a]'
                     }`}
                     onClick={() => setActiveTermTab(tt.id)}
                   >
-                    <TerminalIcon size={11} style={{ color: activeTermTab === tt.id ? agentColor : undefined }} />
+                    <TerminalIcon size={11} aria-hidden style={{ color: activeTermTab === tt.id ? agentColor : undefined }} />
                     <span className="truncate max-w-[120px]">{tt.name}</span>
                     {tt.active && (
                       <span
+                        aria-hidden
                         className="inline-block h-1.5 w-1.5 rounded-full flex-shrink-0"
                         style={{ backgroundColor: agentColor, boxShadow: `0 0 4px ${agentColor}88` }}
                       />
                     )}
                     <button
                       onClick={(e) => { e.stopPropagation(); closeTerminalTab(tt.id) }}
-                      className="opacity-0 group-hover:opacity-100 text-[#667085] hover:text-[#ef4444] transition-opacity"
+                      className="opacity-0 group-hover:opacity-100 text-[#5a6b7f] hover:text-[#ef4444] transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded"
+                      aria-label={`Close terminal ${tt.name}`}
                     >
-                      <X size={11} />
+                      <X size={11} aria-hidden />
                     </button>
                   </div>
                 ))}
                 <button
                   onClick={createNewTerminal}
-                  className="flex items-center justify-center h-full px-2.5 text-[#667085] hover:text-[#e6edf3] hover:bg-[#161b22] transition-colors"
+                  className="flex items-center justify-center h-full px-2.5 text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#11182a] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#00FFA7]/40"
                   title="New terminal"
+                  aria-label="New terminal"
                 >
-                  <Plus size={13} />
+                  <Plus size={13} aria-hidden />
                 </button>
               </div>
             )}
@@ -659,7 +655,7 @@ function InfoRail({
   return (
     <>
       {/* Tab bar */}
-      <div className="flex-shrink-0 flex items-center h-10 px-5 gap-6 border-b border-[#21262d]">
+      <div role="tablist" aria-label="Agent info" className="flex-shrink-0 flex items-center h-10 px-5 gap-6 border-b border-[#152030]">
         <TabButton
           label="Sessions"
           active={tab === 'sessions'}
@@ -694,9 +690,9 @@ function InfoRail({
         )}
 
         {tab === 'profile' && (
-          <div className="px-5 py-4">
+          <div role="tabpanel" className="px-5 py-4">
             {profileLead && (
-              <p className="text-[13px] leading-[1.6] text-[#e6edf3] mb-4 pb-4 border-b border-[#21262d]">
+              <p className="text-[13px] leading-[1.6] text-[#e6edf3] mb-4 pb-4 border-b border-[#152030]">
                 {profileLead}
               </p>
             )}
@@ -714,13 +710,13 @@ function InfoRail({
         )}
 
         {tab === 'memory' && (
-          <div className="px-5 py-4">
+          <div role="tabpanel" className="px-5 py-4">
             {memories.length === 0 ? (
-              <div className="text-[12px] text-[#667085]">
+              <div className="text-[12px] text-[#5a6b7f]">
                 <p className="mb-1">Sem memórias ainda.</p>
                 <p className="text-[11px] text-[#3F3F46]">
                   Adicione arquivos em{' '}
-                  <code className="font-mono text-[#667085]">.claude/agent-memory/{agentSlug}/</code>
+                  <code className="font-mono text-[#5a6b7f]">.claude/agent-memory/{agentSlug}/</code>
                 </p>
               </div>
             ) : (
@@ -731,17 +727,18 @@ function InfoRail({
                     <li key={mem.name}>
                       <button
                         onClick={() => toggleMemory(mem.name)}
-                        className="w-full flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-[#161b22] text-left transition-colors"
+                        aria-expanded={open}
+                        className="w-full flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-[#11182a] text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
                       >
                         {open ? (
-                          <ChevronDown size={11} className="text-[#667085] flex-shrink-0" />
+                          <ChevronDown size={11} aria-hidden className="text-[#5a6b7f] flex-shrink-0" />
                         ) : (
-                          <ChevronRight size={11} className="text-[#3F3F46] flex-shrink-0" />
+                          <ChevronRight size={11} aria-hidden className="text-[#3F3F46] flex-shrink-0" />
                         )}
                         <span className="font-mono text-[11.5px] text-[#e6edf3] truncate">
                           {mem.name}
                         </span>
-                        <span className="ml-auto font-mono text-[10px] text-[#667085] flex-shrink-0">
+                        <span className="ml-auto font-mono text-[10px] text-[#5a6b7f] flex-shrink-0">
                           {formatSize(mem.size)}
                         </span>
                       </button>
@@ -781,8 +778,10 @@ function TabButton({
   return (
     <button
       onClick={onClick}
-      className="relative h-10 flex items-center gap-2 text-[10.5px] uppercase tracking-[0.14em] font-medium transition-colors"
-      style={{ color: active ? '#e6edf3' : '#667085' }}
+      role="tab"
+      aria-selected={active}
+      className="relative h-10 flex items-center gap-2 text-[10.5px] uppercase tracking-[0.14em] font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded px-1"
+      style={{ color: active ? '#e6edf3' : '#5a6b7f' }}
     >
       {label}
       {count !== undefined && (
@@ -790,6 +789,7 @@ function TabButton({
       )}
       {active && (
         <span
+          aria-hidden
           className="absolute bottom-0 left-0 right-0 h-[2px]"
           style={{ backgroundColor: color }}
         />

--- a/dashboard/frontend/src/pages/Agents.tsx
+++ b/dashboard/frontend/src/pages/Agents.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -26,10 +26,12 @@ import {
   Navigation,
   History,
   Lock,
+  X,
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '../lib/api'
 import { AgentAvatar } from '../components/AgentAvatar'
+import { MeshBackground } from '../components/ui'
 
 type Category = 'business' | 'engineering' | 'custom'
 type EngTier = 'reasoning' | 'execution' | 'speed'
@@ -113,150 +115,24 @@ interface AgentMeta {
 }
 
 const AGENT_META: Record<string, AgentMeta> = {
-  'atlas-project': {
-    icon: FolderKanban,
-    color: '#60A5FA',
-    colorMuted: 'rgba(96,165,250,0.12)',
-    glowColor: 'rgba(96,165,250,0.15)',
-    command: '',
-    label: 'Projects',
-  },
-  'clawdia-assistant': {
-    icon: Brain,
-    color: '#22D3EE',
-    colorMuted: 'rgba(34,211,238,0.12)',
-    glowColor: 'rgba(34,211,238,0.15)',
-    command: '/clawdia',
-    label: 'Operations',
-  },
-  'flux-finance': {
-    icon: DollarSign,
-    color: '#34D399',
-    colorMuted: 'rgba(52,211,153,0.12)',
-    glowColor: 'rgba(52,211,153,0.15)',
-    command: '/flux',
-    label: 'Finance',
-  },
-  'kai-personal-assistant': {
-    icon: Heart,
-    color: '#F472B6',
-    colorMuted: 'rgba(244,114,182,0.12)',
-    glowColor: 'rgba(244,114,182,0.15)',
-    command: '/kai',
-    label: 'Personal',
-  },
-  'mentor-courses': {
-    icon: GraduationCap,
-    color: '#FBBF24',
-    colorMuted: 'rgba(251,191,36,0.12)',
-    glowColor: 'rgba(251,191,36,0.15)',
-    command: '/mentor',
-    label: 'Courses',
-  },
-  'nex-sales': {
-    icon: Target,
-    color: '#FB923C',
-    colorMuted: 'rgba(251,146,60,0.12)',
-    glowColor: 'rgba(251,146,60,0.15)',
-    command: '/nex',
-    label: 'Sales',
-  },
-  'pixel-social-media': {
-    icon: Camera,
-    color: '#A78BFA',
-    colorMuted: 'rgba(167,139,250,0.12)',
-    glowColor: 'rgba(167,139,250,0.15)',
-    command: '/pixel',
-    label: 'Social Media',
-  },
-  'pulse-community': {
-    icon: Users,
-    color: '#2DD4BF',
-    colorMuted: 'rgba(45,212,191,0.12)',
-    glowColor: 'rgba(45,212,191,0.15)',
-    command: '/pulse',
-    label: 'Community',
-  },
-  'sage-strategy': {
-    icon: Compass,
-    color: '#818CF8',
-    colorMuted: 'rgba(129,140,248,0.12)',
-    glowColor: 'rgba(129,140,248,0.15)',
-    command: '/sage',
-    label: 'Strategy',
-  },
-  'oracle': {
-    icon: BookOpen,
-    color: '#F59E0B',
-    colorMuted: 'rgba(245,158,11,0.12)',
-    glowColor: 'rgba(245,158,11,0.15)',
-    command: '/oracle',
-    label: 'Knowledge',
-  },
-  'mako-marketing': {
-    icon: Megaphone,
-    color: '#FB923C',
-    colorMuted: 'rgba(251,146,60,0.12)',
-    glowColor: 'rgba(251,146,60,0.15)',
-    command: '/mako',
-    label: 'Marketing',
-  },
-  'aria-hr': {
-    icon: UserCheck,
-    color: '#F472B6',
-    colorMuted: 'rgba(244,114,182,0.12)',
-    glowColor: 'rgba(244,114,182,0.15)',
-    command: '/aria',
-    label: 'HR / People',
-  },
-  'zara-cs': {
-    icon: Headphones,
-    color: '#22D3EE',
-    colorMuted: 'rgba(34,211,238,0.12)',
-    glowColor: 'rgba(34,211,238,0.15)',
-    command: '/zara',
-    label: 'Customer Success',
-  },
-  'lex-legal': {
-    icon: Scale,
-    color: '#C084FC',
-    colorMuted: 'rgba(192,132,252,0.12)',
-    glowColor: 'rgba(192,132,252,0.15)',
-    command: '/lex',
-    label: 'Legal',
-  },
-  'nova-product': {
-    icon: Lightbulb,
-    color: '#60A5FA',
-    colorMuted: 'rgba(96,165,250,0.12)',
-    glowColor: 'rgba(96,165,250,0.15)',
-    command: '/nova',
-    label: 'Product',
-  },
-  'dex-data': {
-    icon: BarChart3,
-    color: '#FBBF24',
-    colorMuted: 'rgba(251,191,36,0.12)',
-    glowColor: 'rgba(251,191,36,0.15)',
-    command: '/dex',
-    label: 'Data / BI',
-  },
-  'helm-conductor': {
-    icon: Navigation,
-    color: '#14B8A6',
-    colorMuted: 'rgba(20,184,166,0.12)',
-    glowColor: 'rgba(20,184,166,0.15)',
-    command: '/helm-conductor',
-    label: 'Cycle Orchestration',
-  },
-  'mirror-retro': {
-    icon: History,
-    color: '#94A3B8',
-    colorMuted: 'rgba(148,163,184,0.12)',
-    glowColor: 'rgba(148,163,184,0.15)',
-    command: '/mirror-retro',
-    label: 'Retrospective',
-  },
+  'atlas-project': { icon: FolderKanban, color: '#60A5FA', colorMuted: 'rgba(96,165,250,0.12)', glowColor: 'rgba(96,165,250,0.15)', command: '', label: 'Projects' },
+  'clawdia-assistant': { icon: Brain, color: '#22D3EE', colorMuted: 'rgba(34,211,238,0.12)', glowColor: 'rgba(34,211,238,0.15)', command: '/clawdia', label: 'Operations' },
+  'flux-finance': { icon: DollarSign, color: '#34D399', colorMuted: 'rgba(52,211,153,0.12)', glowColor: 'rgba(52,211,153,0.15)', command: '/flux', label: 'Finance' },
+  'kai-personal-assistant': { icon: Heart, color: '#F472B6', colorMuted: 'rgba(244,114,182,0.12)', glowColor: 'rgba(244,114,182,0.15)', command: '/kai', label: 'Personal' },
+  'mentor-courses': { icon: GraduationCap, color: '#FBBF24', colorMuted: 'rgba(251,191,36,0.12)', glowColor: 'rgba(251,191,36,0.15)', command: '/mentor', label: 'Courses' },
+  'nex-sales': { icon: Target, color: '#FB923C', colorMuted: 'rgba(251,146,60,0.12)', glowColor: 'rgba(251,146,60,0.15)', command: '/nex', label: 'Sales' },
+  'pixel-social-media': { icon: Camera, color: '#A78BFA', colorMuted: 'rgba(167,139,250,0.12)', glowColor: 'rgba(167,139,250,0.15)', command: '/pixel', label: 'Social Media' },
+  'pulse-community': { icon: Users, color: '#2DD4BF', colorMuted: 'rgba(45,212,191,0.12)', glowColor: 'rgba(45,212,191,0.15)', command: '/pulse', label: 'Community' },
+  'sage-strategy': { icon: Compass, color: '#818CF8', colorMuted: 'rgba(129,140,248,0.12)', glowColor: 'rgba(129,140,248,0.15)', command: '/sage', label: 'Strategy' },
+  'oracle': { icon: BookOpen, color: '#F59E0B', colorMuted: 'rgba(245,158,11,0.12)', glowColor: 'rgba(245,158,11,0.15)', command: '/oracle', label: 'Knowledge' },
+  'mako-marketing': { icon: Megaphone, color: '#FB923C', colorMuted: 'rgba(251,146,60,0.12)', glowColor: 'rgba(251,146,60,0.15)', command: '/mako', label: 'Marketing' },
+  'aria-hr': { icon: UserCheck, color: '#F472B6', colorMuted: 'rgba(244,114,182,0.12)', glowColor: 'rgba(244,114,182,0.15)', command: '/aria', label: 'HR / People' },
+  'zara-cs': { icon: Headphones, color: '#22D3EE', colorMuted: 'rgba(34,211,238,0.12)', glowColor: 'rgba(34,211,238,0.15)', command: '/zara', label: 'Customer Success' },
+  'lex-legal': { icon: Scale, color: '#C084FC', colorMuted: 'rgba(192,132,252,0.12)', glowColor: 'rgba(192,132,252,0.15)', command: '/lex', label: 'Legal' },
+  'nova-product': { icon: Lightbulb, color: '#60A5FA', colorMuted: 'rgba(96,165,250,0.12)', glowColor: 'rgba(96,165,250,0.15)', command: '/nova', label: 'Product' },
+  'dex-data': { icon: BarChart3, color: '#FBBF24', colorMuted: 'rgba(251,191,36,0.12)', glowColor: 'rgba(251,191,36,0.15)', command: '/dex', label: 'Data / BI' },
+  'helm-conductor': { icon: Navigation, color: '#14B8A6', colorMuted: 'rgba(20,184,166,0.12)', glowColor: 'rgba(20,184,166,0.15)', command: '/helm-conductor', label: 'Cycle Orchestration' },
+  'mirror-retro': { icon: History, color: '#94A3B8', colorMuted: 'rgba(148,163,184,0.12)', glowColor: 'rgba(148,163,184,0.15)', command: '/mirror-retro', label: 'Retrospective' },
 }
 
 const DEFAULT_META: AgentMeta = {
@@ -273,13 +149,7 @@ function getMeta(name: string, agent?: Agent): AgentMeta {
   if (AGENT_META[name]) return { ...AGENT_META[name], command }
   if (agent?.color) {
     const c = agent.color
-    return {
-      ...DEFAULT_META,
-      color: c,
-      colorMuted: `${c}1F`,
-      glowColor: `${c}26`,
-      command,
-    }
+    return { ...DEFAULT_META, color: c, colorMuted: `${c}1F`, glowColor: `${c}26`, command }
   }
   return { ...DEFAULT_META, command }
 }
@@ -299,24 +169,20 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
 
   if (locked) {
     return (
-      <div
-        className="group relative block rounded-xl border border-[#21262d] bg-[#161b22] p-3.5 opacity-50 grayscale cursor-not-allowed"
+      <article
+        className="group relative block rounded-xl border border-[#152030] bg-[#0b1018] p-3.5 opacity-50 grayscale cursor-not-allowed"
+        aria-label={`${formatAgentName(agent.name)} — sem acesso`}
         title="Sem acesso"
       >
-        {/* Lock overlay */}
-        <div className="absolute top-2.5 right-2.5 z-10 flex items-center justify-center w-6 h-6 rounded-full bg-[#0d1117] border border-[#21262d]">
-          <Lock size={12} className="text-[#667085]" />
+        <div className="absolute top-2.5 right-2.5 z-10 flex items-center justify-center w-6 h-6 rounded-full bg-[#080c14] border border-[#152030]">
+          <Lock size={12} className="text-[#5a6b7f]" aria-hidden />
         </div>
 
-        {/* Top row: avatar + status */}
         <div className="relative flex items-start justify-between mb-3">
-          <div>
-            <AgentAvatar name={agent.name} size={56} />
-          </div>
-          <span className="inline-block h-2 w-2 rounded-full mt-7" style={{ backgroundColor: '#3F3F46' }} />
+          <AgentAvatar name={agent.name} size={56} />
+          <span aria-hidden className="inline-block h-2 w-2 rounded-full mt-7 bg-[#3F3F46]" />
         </div>
 
-        {/* Name + domain label */}
         <div className="relative mb-1.5">
           <h3 className="text-[13px] font-semibold text-[#e6edf3]">
             {formatAgentName(agent.name)}
@@ -328,34 +194,41 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
           </div>
         </div>
 
-        {/* Description */}
-        <p className="relative mb-3 text-[11px] leading-relaxed text-[#667085] line-clamp-2">
+        <p className="relative mb-3 text-[11px] leading-relaxed text-[#5a6b7f] line-clamp-2">
           {agent.description || 'No description available.'}
         </p>
 
-        {/* Bottom row */}
         <div className="relative flex items-center justify-between">
-          <span className="text-[10px] text-[#667085]">Sem acesso</span>
-          <div className="flex items-center gap-1 rounded-full bg-[#0d1117] px-2 py-0.5 border border-[#21262d]">
-            <Brain size={10} className="text-[#667085]" />
+          <span className="text-[10px] text-[#5a6b7f]">Sem acesso</span>
+          <div className="flex items-center gap-1 rounded-full bg-[#080c14] px-2 py-0.5 border border-[#152030]">
+            <Brain size={10} className="text-[#5a6b7f]" aria-hidden />
             <span className="text-[10px] font-medium text-[#8b949e]">{agent.memory_count}</span>
           </div>
         </div>
-      </div>
+      </article>
     )
   }
 
   return (
     <Link
       to={`/agents/${agent.name}`}
-      className="group relative block rounded-xl border border-[#21262d] bg-[#161b22] p-3.5 transition-all duration-300 hover:border-transparent"
+      aria-label={`Open ${formatAgentName(agent.name)}${isRunning ? ' (running)' : ''}`}
+      className="group relative block rounded-xl border border-[#152030] bg-[#0b1018] p-3.5 transition-all duration-300 hover:border-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[#080c14]"
       style={{
         ['--agent-color' as string]: meta.color,
         ['--agent-glow' as string]: meta.glowColor,
       }}
     >
-      {/* Hover glow effect */}
+      {/* Top gradient accent */}
+      <span
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-px rounded-t-xl bg-gradient-to-r from-transparent to-transparent opacity-60"
+        style={{ background: `linear-gradient(90deg, transparent, ${meta.color}66, transparent)` }}
+      />
+
+      {/* Hover glow */}
       <div
+        aria-hidden
         className="pointer-events-none absolute inset-0 rounded-xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
         style={{
           boxShadow: `inset 0 0 0 1px ${meta.color}44, 0 0 20px ${meta.glowColor}`,
@@ -369,18 +242,18 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
           <AgentAvatar name={agent.name} size={56} />
         </div>
 
-        {/* Status dot + running badge */}
         <div className="flex items-center gap-2">
           {isRunning && (
             <span className="flex items-center gap-1 rounded-full bg-[#00FFA7]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#00FFA7] border border-[#00FFA7]/20">
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00FFA7] opacity-75" />
+              <span aria-hidden className="relative flex h-1.5 w-1.5">
+                <span className="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-[#00FFA7] opacity-75" />
                 <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-[#00FFA7]" />
               </span>
-              Running
+              <span className="sr-only">Status: </span>Running
             </span>
           )}
           <span
+            aria-hidden
             className="inline-block h-2 w-2 rounded-full"
             style={{
               backgroundColor: isActive ? '#22C55E' : '#3F3F46',
@@ -395,10 +268,10 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
         <h3 className="text-[13px] font-semibold text-[#e6edf3] transition-colors duration-200 group-hover:text-white">
           {formatAgentName(agent.name)}
         </h3>
-        <div className="mt-1 flex items-center gap-2">
+        <div className="mt-1 flex items-center gap-2 flex-wrap">
           <span
             className="inline-block text-[10px] font-medium uppercase tracking-wider"
-            style={{ color: meta.color, opacity: 0.8 }}
+            style={{ color: meta.color, opacity: 0.85 }}
           >
             {meta.label}
           </span>
@@ -420,25 +293,23 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
       </div>
 
       {/* Description */}
-      <p className="relative mb-3 text-[11px] leading-relaxed text-[#667085] line-clamp-2">
+      <p className="relative mb-3 text-[11px] leading-relaxed text-[#8b949e] line-clamp-2">
         {agent.description || 'No description available.'}
       </p>
 
-      {/* Bottom row: command badge + memory badge */}
+      {/* Bottom row */}
       <div className="relative flex items-center justify-between">
         {meta.command ? (
-          <code className="rounded-md bg-[#0d1117] px-1.5 py-0.5 font-mono text-[10px] text-[#8b949e] border border-[#21262d]">
+          <code className="rounded-md bg-[#080c14] px-1.5 py-0.5 font-mono text-[10px] text-[#8b949e] border border-[#152030]">
             {meta.command}
           </code>
         ) : (
           <span />
         )}
 
-        <div className="flex items-center gap-1 rounded-full bg-[#0d1117] px-2 py-0.5 border border-[#21262d]">
-          <Brain size={10} className="text-[#667085]" />
-          <span className="text-[10px] font-medium text-[#8b949e]">
-            {agent.memory_count}
-          </span>
+        <div className="flex items-center gap-1 rounded-full bg-[#080c14] px-2 py-0.5 border border-[#152030]">
+          <Brain size={10} className="text-[#5a6b7f]" aria-hidden />
+          <span className="text-[10px] font-medium text-[#8b949e]">{agent.memory_count}</span>
         </div>
       </div>
     </Link>
@@ -447,20 +318,20 @@ function AgentCard({ agent, isRunning }: { agent: Agent; isRunning: boolean }) {
 
 function SkeletonCard() {
   return (
-    <div className="rounded-xl border border-[#21262d] bg-[#161b22] p-5">
+    <div aria-hidden className="rounded-xl border border-[#152030] bg-[#0b1018] p-5">
       <div className="flex items-start justify-between mb-4">
-        <div className="h-10 w-10 rounded-lg bg-[#21262d] animate-pulse" />
-        <div className="h-2 w-2 rounded-full bg-[#21262d] animate-pulse" />
+        <div className="h-10 w-10 rounded-lg bg-[#152030] animate-pulse" />
+        <div className="h-2 w-2 rounded-full bg-[#152030] animate-pulse" />
       </div>
-      <div className="h-4 w-32 rounded bg-[#21262d] animate-pulse mb-2" />
-      <div className="h-3 w-16 rounded bg-[#21262d] animate-pulse mb-3" />
+      <div className="h-4 w-32 rounded bg-[#152030] animate-pulse mb-2" />
+      <div className="h-3 w-16 rounded bg-[#152030] animate-pulse mb-3" />
       <div className="space-y-1.5 mb-4">
-        <div className="h-3 w-full rounded bg-[#21262d] animate-pulse" />
-        <div className="h-3 w-2/3 rounded bg-[#21262d] animate-pulse" />
+        <div className="h-3 w-full rounded bg-[#152030] animate-pulse" />
+        <div className="h-3 w-2/3 rounded bg-[#152030] animate-pulse" />
       </div>
       <div className="flex items-center justify-between">
-        <div className="h-6 w-16 rounded-md bg-[#21262d] animate-pulse" />
-        <div className="h-6 w-12 rounded-full bg-[#21262d] animate-pulse" />
+        <div className="h-6 w-16 rounded-md bg-[#152030] animate-pulse" />
+        <div className="h-6 w-12 rounded-full bg-[#152030] animate-pulse" />
       </div>
     </div>
   )
@@ -470,7 +341,7 @@ function OracleHeroCard({ agent, isRunning }: { agent: Agent; isRunning: boolean
   if (agent.locked) {
     return (
       <div
-        className="group relative block overflow-hidden rounded-2xl border border-[#21262d] bg-[#11110c] opacity-50 grayscale cursor-not-allowed"
+        className="group relative block overflow-hidden rounded-2xl border border-[#152030] bg-[#11110c] opacity-50 grayscale cursor-not-allowed"
         title="Sem acesso"
       >
         <div className="relative flex items-center gap-5 px-6 py-5">
@@ -479,7 +350,7 @@ function OracleHeroCard({ agent, isRunning }: { agent: Agent; isRunning: boolean
             <h2 className="text-[22px] font-bold text-[#F9FAFB] leading-tight mb-0.5">Oracle</h2>
             <p className="text-[12.5px] text-[#8b949e] leading-snug">Sem acesso</p>
           </div>
-          <Lock size={16} className="flex-shrink-0 text-[#667085]" />
+          <Lock size={16} className="flex-shrink-0 text-[#5a6b7f]" aria-hidden />
         </div>
       </div>
     )
@@ -488,33 +359,32 @@ function OracleHeroCard({ agent, isRunning }: { agent: Agent; isRunning: boolean
   return (
     <Link
       to={`/agents/${agent.name}`}
-      className="group relative block overflow-hidden rounded-2xl border border-[#F59E0B]/25 bg-[#11110c] transition-all duration-300 hover:border-[#F59E0B]/50"
+      aria-label="Open Oracle — start here"
+      className="group relative block overflow-hidden rounded-2xl border border-[#F59E0B]/25 bg-[#11110c] transition-all duration-300 hover:border-[#F59E0B]/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F59E0B]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[#080c14]"
       style={{
         boxShadow: '0 0 32px rgba(245,158,11,0.06), inset 0 1px 0 rgba(245,158,11,0.08)',
       }}
     >
-      {/* Ambient glow */}
       <div
+        aria-hidden
         className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full blur-3xl opacity-30 transition-opacity duration-500 group-hover:opacity-50"
         style={{ background: 'radial-gradient(circle, rgba(245,158,11,0.35), transparent 65%)' }}
       />
 
       <div className="relative flex items-center gap-5 px-6 py-5">
-        {/* Avatar */}
         <div className="transition-transform duration-300 group-hover:scale-105" style={{ filter: 'drop-shadow(0 0 12px rgba(245,158,11,0.3))' }}>
           <AgentAvatar name={agent.name} size={56} />
         </div>
 
-        {/* Content */}
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
             <span className="rounded-full bg-[#F59E0B]/15 px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.14em] text-[#F59E0B] border border-[#F59E0B]/30">
               Start Here
             </span>
             {isRunning && (
               <span className="flex items-center gap-1 rounded-full bg-[#00FFA7]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-[#00FFA7] border border-[#00FFA7]/20">
-                <span className="relative flex h-1.5 w-1.5">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#00FFA7] opacity-75" />
+                <span aria-hidden className="relative flex h-1.5 w-1.5">
+                  <span className="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-[#00FFA7] opacity-75" />
                   <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-[#00FFA7]" />
                 </span>
                 Running
@@ -530,10 +400,9 @@ function OracleHeroCard({ agent, isRunning }: { agent: Agent; isRunning: boolean
           </p>
         </div>
 
-        {/* CTA arrow */}
         <div className="hidden sm:flex flex-shrink-0 items-center gap-1.5 text-[11px] uppercase tracking-[0.14em] font-semibold text-[#F59E0B]/70 group-hover:text-[#F59E0B] transition-colors">
           Open
-          <span className="transition-transform duration-300 group-hover:translate-x-1">→</span>
+          <span aria-hidden className="transition-transform duration-300 group-hover:translate-x-1">→</span>
         </div>
       </div>
     </Link>
@@ -585,17 +454,17 @@ function SectionHeader({
   description?: string
 }) {
   return (
-    <div className="mb-3 flex items-end justify-between border-b border-[#21262d] pb-2">
+    <div className="mb-3 flex items-end justify-between border-b border-[#152030] pb-2">
       <div className="flex items-baseline gap-3">
-        <h2 className="text-sm font-semibold uppercase tracking-wider text-[#e6edf3]" style={{ color }}>
+        <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color }}>
           {label}
         </h2>
-        <span className="rounded-full bg-[#0d1117] px-2 py-0.5 text-[11px] font-medium text-[#8b949e] border border-[#21262d]">
+        <span className="rounded-full bg-[#080c14] px-2 py-0.5 text-[11px] font-medium text-[#8b949e] border border-[#152030]">
           {count}
         </span>
       </div>
       {description && (
-        <p className="hidden md:block text-[11px] text-[#667085]">{description}</p>
+        <p className="hidden md:block text-[11px] text-[#5a6b7f]">{description}</p>
       )}
     </div>
   )
@@ -604,9 +473,9 @@ function SectionHeader({
 function SubSectionHeader({ label, count }: { label: string; count: number }) {
   return (
     <div className="mb-2 mt-4 flex items-center gap-2">
-      <h3 className="text-[11px] font-medium uppercase tracking-wider text-[#667085]">{label}</h3>
-      <span className="text-[11px] text-[#3F3F46]">·</span>
-      <span className="text-[11px] text-[#667085]">{count}</span>
+      <h3 className="text-[11px] font-medium uppercase tracking-wider text-[#5a6b7f]">{label}</h3>
+      <span aria-hidden className="text-[11px] text-[#3F3F46]">·</span>
+      <span className="text-[11px] text-[#5a6b7f]">{count}</span>
     </div>
   )
 }
@@ -643,6 +512,7 @@ export default function Agents() {
   const [filter, setFilter] = useState<FilterValue>('all')
   const [query, setQuery] = useState('')
   const [recentNames] = useState(getRecentAgents)
+  const searchRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     api.get('/agents')
@@ -665,6 +535,18 @@ export default function Agents() {
     fetchActive()
     const interval = setInterval(fetchActive, 5000)
     return () => clearInterval(interval)
+  }, [])
+
+  // Keyboard shortcut: "/" focuses search
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') {
+        e.preventDefault()
+        searchRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
   }, [])
 
   const totalMemories = agents.reduce((sum, a) => sum + a.memory_count, 0)
@@ -729,62 +611,60 @@ export default function Agents() {
     'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3'
 
   return (
-    <div>
-      {/* Header */}
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-[#e6edf3]">{t('agents.title')}</h1>
-        <p className="text-[#667085] mt-1">{t('agents.headerSubtitle')}</p>
-
-        {/* Stats bar */}
-        {!loading && agents.length > 0 && (
-          <div className="mt-4 flex items-center gap-6 text-sm">
-            <div className="flex items-center gap-2">
-              <span
-                className="inline-block h-2 w-2 rounded-full bg-[#22C55E]"
-                style={{ boxShadow: '0 0 6px rgba(34,197,94,0.5)' }}
-              />
-              <span className="text-[#8b949e]">
-                <span className="font-medium text-[#e6edf3]">{activeCount}</span> active
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Brain size={14} className="text-[#667085]" />
-              <span className="text-[#8b949e]">
-                <span className="font-medium text-[#e6edf3]">{totalMemories}</span> total memories
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Building2 size={14} className="text-[#00FFA7]" />
-              <span className="text-[#8b949e]">
-                <span className="font-medium text-[#e6edf3]">{counts.business}</span> business
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Code2 size={14} className="text-[#818CF8]" />
-              <span className="text-[#8b949e]">
-                <span className="font-medium text-[#e6edf3]">{counts.engineering}</span> engineering
-              </span>
-            </div>
-            {counts.custom > 0 && (
-              <div className="flex items-center gap-2">
-                <Sparkles size={14} className="text-[#C084FC]" />
-                <span className="text-[#8b949e]">
-                  <span className="font-medium text-[#e6edf3]">{counts.custom}</span> custom
-                </span>
-              </div>
-            )}
-          </div>
-        )}
+    <div className="relative">
+      {/* Subtle mesh background — only in hero area, low density for performance */}
+      <div className="absolute inset-x-0 top-0 h-72 overflow-hidden pointer-events-none -mx-4 lg:-mx-8 -mt-16 lg:-mt-8">
+        <MeshBackground
+          density={32000}
+          maxParticles={36}
+          maxDistance={120}
+          className="absolute inset-0 opacity-50"
+        />
+        <div
+          aria-hidden
+          className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-[#0C111D]"
+        />
       </div>
+
+      {/* Header (premium) */}
+      <header className="relative mb-6">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <div className="flex items-center gap-2.5 mb-1.5">
+              <div className="flex items-center justify-center w-9 h-9 rounded-xl bg-[#00FFA7]/10 border border-[#00FFA7]/20">
+                <Bot size={18} className="text-[#00FFA7]" aria-hidden />
+              </div>
+              <h1 className="text-2xl font-bold text-[#F9FAFB] tracking-tight">{t('agents.title')}</h1>
+            </div>
+            <p className="text-[#8b949e] text-sm ml-[2.875rem]">{t('agents.headerSubtitle')}</p>
+          </div>
+
+          {/* Stats pills */}
+          {!loading && agents.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-medium bg-[#0b1018] border border-[#152030] text-[#e6edf3]">
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-[#22C55E] shadow-[0_0_6px_rgba(34,197,94,0.5)]" />
+                {activeCount} active
+              </span>
+              <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-medium bg-[#0b1018] border border-[#152030] text-[#8b949e]">
+                <Brain size={11} aria-hidden />
+                {totalMemories} memories
+              </span>
+            </div>
+          )}
+        </div>
+      </header>
 
       {/* Recent agents */}
       {!loading && recentNames.length > 0 && filter === 'all' && !query && (
-        <div className="mb-6">
+        <section aria-labelledby="recent-heading" className="relative mb-6">
           <div className="flex items-center gap-2 mb-3">
-            <History size={13} className="text-[#667085]" />
-            <h2 className="text-[11px] font-medium uppercase tracking-wider text-[#667085]">Recent</h2>
+            <History size={13} className="text-[#5a6b7f]" aria-hidden />
+            <h2 id="recent-heading" className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#5a6b7f]">
+              Recent
+            </h2>
           </div>
-          <div className="flex gap-2 overflow-x-auto pb-1">
+          <div className="flex gap-2 overflow-x-auto pb-1 scroll-smooth">
             {recentNames
               .filter(n => agents.some(a => a.name === n))
               .map(name => {
@@ -794,20 +674,21 @@ export default function Agents() {
                   <Link
                     key={name}
                     to={`/agents/${name}`}
-                    className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-[#21262d] bg-[#161b22] hover:border-[#30363d] hover:bg-[#1c2333] transition-all flex-shrink-0 group"
+                    aria-label={`Open ${formatAgentName(name)}${running ? ' (running)' : ''}`}
+                    className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-[#152030] bg-[#0b1018] hover:border-[#1e2d3d] hover:bg-[#11182a] transition-all flex-shrink-0 group focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
                   >
                     <div className="relative flex-shrink-0">
                       <AgentAvatar name={name} size={28} />
                       {running && (
                         <span
-                          className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-[#161b22]"
-                          style={{ backgroundColor: '#22C55E', boxShadow: '0 0 6px rgba(34,197,94,0.5)' }}
+                          aria-hidden
+                          className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-[#0b1018] bg-[#22C55E] shadow-[0_0_6px_rgba(34,197,94,0.5)]"
                         />
                       )}
                     </div>
                     <div className="flex flex-col min-w-0">
                       <span className="text-[12px] font-medium text-[#e6edf3] group-hover:text-white truncate">
-                        {name.split('-').map(w => w[0].toUpperCase() + w.slice(1)).join(' ')}
+                        {formatAgentName(name)}
                       </span>
                       <span className="text-[10px] font-mono" style={{ color: meta.color }}>
                         {meta.command}
@@ -817,72 +698,96 @@ export default function Agents() {
                 )
               })}
           </div>
-        </div>
+        </section>
       )}
 
-      {/* Filter + Search bar */}
+      {/* Filter + Search bar (sticky) */}
       {!loading && agents.length > 0 && (
-        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-2">
-            {FILTERS.map((f) => {
-              const FIcon = f.icon
-              const active = filter === f.value
-              const c = counts[f.value]
-              return (
-                <button
-                  key={f.value}
-                  onClick={() => setFilter(f.value)}
-                  className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-all ${
-                    active
-                      ? 'border-[#00FFA7]/40 bg-[#00FFA7]/10 text-[#00FFA7]'
-                      : 'border-[#21262d] bg-[#161b22] text-[#8b949e] hover:border-[#30363d] hover:text-[#e6edf3]'
-                  }`}
-                >
-                  <FIcon size={12} />
-                  {f.label}
-                  <span className="rounded-full bg-[#0d1117] px-1.5 py-0.5 text-[10px] text-[#667085] border border-[#21262d]">
-                    {c}
-                  </span>
-                </button>
-              )
-            })}
-          </div>
+        <div className="sticky top-0 z-20 -mx-4 lg:-mx-8 px-4 lg:px-8 py-3 mb-6 bg-[#0C111D]/85 backdrop-blur-md border-b border-[#152030]/60">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div role="tablist" aria-label="Filter by category" className="flex flex-wrap items-center gap-2">
+              {FILTERS.map((f) => {
+                const FIcon = f.icon
+                const active = filter === f.value
+                const c = counts[f.value]
+                return (
+                  <button
+                    key={f.value}
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setFilter(f.value)}
+                    className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 ${
+                      active
+                        ? 'border-[#00FFA7]/40 bg-[#00FFA7]/10 text-[#00FFA7]'
+                        : 'border-[#152030] bg-[#0b1018] text-[#8b949e] hover:border-[#1e2d3d] hover:text-[#e6edf3]'
+                    }`}
+                  >
+                    <FIcon size={12} aria-hidden />
+                    {f.label}
+                    <span className="rounded-full bg-[#080c14] px-1.5 py-0.5 text-[10px] text-[#5a6b7f] border border-[#152030]">
+                      {c}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
 
-          <div className="relative sm:w-64">
-            <Search
-              size={14}
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-[#667085]"
-            />
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search agents..."
-              className="w-full rounded-full border border-[#21262d] bg-[#161b22] py-1.5 pl-9 pr-3 text-[12px] text-[#e6edf3] placeholder:text-[#667085] focus:border-[#00FFA7]/40 focus:outline-none"
-            />
+            <div className="relative sm:w-72">
+              <label htmlFor="agents-search" className="sr-only">Search agents</label>
+              <Search
+                size={14}
+                aria-hidden
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[#5a6b7f]"
+              />
+              <input
+                id="agents-search"
+                ref={searchRef}
+                type="search"
+                role="searchbox"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search agents…  (press / to focus)"
+                className="w-full rounded-full border border-[#152030] bg-[#0b1018] py-1.5 pl-9 pr-9 text-[12px] text-[#e6edf3] placeholder:text-[#5a6b7f] focus:border-[#00FFA7]/60 focus:ring-1 focus:ring-[#00FFA7]/20 focus:outline-none transition-colors"
+              />
+              {query && (
+                <button
+                  onClick={() => { setQuery(''); searchRef.current?.focus() }}
+                  aria-label="Clear search"
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded-full text-[#5a6b7f] hover:text-[#e6edf3] hover:bg-[#152030] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40"
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       )}
 
       {loading ? (
-        <div className={gridClass}>
+        <div className={gridClass} aria-label="Loading agents">
           {[...Array(9)].map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       ) : agents.length === 0 ? (
         <div className="text-center py-16">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-[#161b22] border border-[#21262d]">
-            <Bot size={32} className="text-[#3F3F46]" />
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-[#0b1018] border border-[#152030]">
+            <Bot size={32} className="text-[#3F3F46]" aria-hidden />
           </div>
-          <p className="text-[#667085] text-lg">No agents found</p>
-          <p className="text-[#3F3F46] text-sm mt-1">
+          <p className="text-[#8b949e] text-lg">No agents found</p>
+          <p className="text-[#5a6b7f] text-sm mt-1">
             Add agent files to .claude/agents/ to get started
           </p>
         </div>
       ) : filtered.length === 0 ? (
         <div className="text-center py-16">
-          <p className="text-[#667085] text-sm">No agents match your filters.</p>
+          <p className="text-[#8b949e] text-sm">No agents match your filters.</p>
+          <button
+            onClick={() => { setQuery(''); setFilter('all') }}
+            className="mt-3 text-[12px] text-[#00FFA7] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00FFA7]/40 rounded px-2 py-1"
+          >
+            Reset filters
+          </button>
         </div>
       ) : (
         <div className="space-y-10">
@@ -890,7 +795,7 @@ export default function Agents() {
             <OracleHeroCard agent={grouped.oracle} isRunning={isRunning(grouped.oracle.name)} />
           )}
           {grouped.business.length > 0 && (
-            <section>
+            <section aria-labelledby="business-heading">
               <SectionHeader
                 label={CATEGORY_META.business.label}
                 count={grouped.business.length}
@@ -909,7 +814,7 @@ export default function Agents() {
             grouped.engineering.execution.length > 0 ||
             grouped.engineering.speed.length > 0 ||
             grouped.engineering.other.length > 0) && (
-            <section>
+            <section aria-labelledby="engineering-heading">
               <SectionHeader
                 label={CATEGORY_META.engineering.label}
                 count={
@@ -947,7 +852,7 @@ export default function Agents() {
           )}
 
           {grouped.custom.length > 0 && (
-            <section>
+            <section aria-labelledby="custom-heading">
               <SectionHeader
                 label={CATEGORY_META.custom.label}
                 count={grouped.custom.length}

--- a/dashboard/frontend/src/pages/Login.tsx
+++ b/dashboard/frontend/src/pages/Login.tsx
@@ -1,81 +1,7 @@
-import { useState, useEffect, useRef, type FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../context/AuthContext'
-
-/* ── Animated mesh background ── */
-function NetworkCanvas() {
-  const ref = useRef<HTMLCanvasElement>(null)
-
-  useEffect(() => {
-    const canvas = ref.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    let animId: number
-    let particles: { x: number; y: number; vx: number; vy: number }[] = []
-
-    const resize = () => {
-      canvas.width = window.innerWidth
-      canvas.height = window.innerHeight
-    }
-
-    const init = () => {
-      resize()
-      const count = Math.floor((canvas.width * canvas.height) / 18000)
-      particles = Array.from({ length: Math.min(count, 80) }, () => ({
-        x: Math.random() * canvas.width,
-        y: Math.random() * canvas.height,
-        vx: (Math.random() - 0.5) * 0.3,
-        vy: (Math.random() - 0.5) * 0.3,
-      }))
-    }
-
-    const draw = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      const maxDist = 150
-
-      for (let i = 0; i < particles.length; i++) {
-        const p = particles[i]
-        p.x += p.vx
-        p.y += p.vy
-        if (p.x < 0 || p.x > canvas.width) p.vx *= -1
-        if (p.y < 0 || p.y > canvas.height) p.vy *= -1
-
-        ctx.beginPath()
-        ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2)
-        ctx.fillStyle = 'rgba(0, 255, 167, 0.25)'
-        ctx.fill()
-
-        for (let j = i + 1; j < particles.length; j++) {
-          const q = particles[j]
-          const dx = p.x - q.x
-          const dy = p.y - q.y
-          const dist = Math.sqrt(dx * dx + dy * dy)
-          if (dist < maxDist) {
-            ctx.beginPath()
-            ctx.moveTo(p.x, p.y)
-            ctx.lineTo(q.x, q.y)
-            ctx.strokeStyle = `rgba(0, 255, 167, ${0.06 * (1 - dist / maxDist)})`
-            ctx.lineWidth = 0.5
-            ctx.stroke()
-          }
-        }
-      }
-      animId = requestAnimationFrame(draw)
-    }
-
-    init()
-    draw()
-    window.addEventListener('resize', init)
-    return () => {
-      cancelAnimationFrame(animId)
-      window.removeEventListener('resize', init)
-    }
-  }, [])
-
-  return <canvas ref={ref} className="fixed inset-0 pointer-events-none" style={{ zIndex: 0 }} />
-}
+import { MeshBackground } from '../components/ui'
 
 export default function Login() {
   const { t } = useTranslation()
@@ -107,7 +33,7 @@ export default function Login() {
 
   return (
     <div className="min-h-screen bg-[#080c14] flex items-center justify-center px-4 font-[Inter,-apple-system,sans-serif] relative">
-      <NetworkCanvas />
+      <MeshBackground />
 
       <div className="w-full max-w-[380px] relative z-10">
         <div className="rounded-xl border border-[#152030] bg-[#0b1018] shadow-[0_4px_40px_rgba(0,0,0,0.4)]">

--- a/dashboard/frontend/src/pages/Setup.tsx
+++ b/dashboard/frontend/src/pages/Setup.tsx
@@ -1,85 +1,9 @@
-import { useState, useEffect, useRef, useCallback, type FormEvent } from 'react'
+import { useState, useEffect, useCallback, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../context/AuthContext'
 import { api } from '../lib/api'
 import { setWorkspaceLanguage } from '../i18n'
-
-/* ── Animated mesh background ── */
-function NetworkCanvas() {
-  const ref = useRef<HTMLCanvasElement>(null)
-
-  useEffect(() => {
-    const canvas = ref.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    let animId: number
-    let particles: { x: number; y: number; vx: number; vy: number }[] = []
-
-    const resize = () => {
-      canvas.width = window.innerWidth
-      canvas.height = window.innerHeight
-    }
-
-    const init = () => {
-      resize()
-      const count = Math.floor((canvas.width * canvas.height) / 18000)
-      particles = Array.from({ length: Math.min(count, 80) }, () => ({
-        x: Math.random() * canvas.width,
-        y: Math.random() * canvas.height,
-        vx: (Math.random() - 0.5) * 0.3,
-        vy: (Math.random() - 0.5) * 0.3,
-      }))
-    }
-
-    const draw = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      const maxDist = 150
-
-      for (let i = 0; i < particles.length; i++) {
-        const p = particles[i]
-        p.x += p.vx
-        p.y += p.vy
-        if (p.x < 0 || p.x > canvas.width) p.vx *= -1
-        if (p.y < 0 || p.y > canvas.height) p.vy *= -1
-
-        // Node
-        ctx.beginPath()
-        ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2)
-        ctx.fillStyle = 'rgba(0, 255, 167, 0.25)'
-        ctx.fill()
-
-        // Edges
-        for (let j = i + 1; j < particles.length; j++) {
-          const q = particles[j]
-          const dx = p.x - q.x
-          const dy = p.y - q.y
-          const dist = Math.sqrt(dx * dx + dy * dy)
-          if (dist < maxDist) {
-            ctx.beginPath()
-            ctx.moveTo(p.x, p.y)
-            ctx.lineTo(q.x, q.y)
-            ctx.strokeStyle = `rgba(0, 255, 167, ${0.06 * (1 - dist / maxDist)})`
-            ctx.lineWidth = 0.5
-            ctx.stroke()
-          }
-        }
-      }
-      animId = requestAnimationFrame(draw)
-    }
-
-    init()
-    draw()
-    window.addEventListener('resize', init)
-    return () => {
-      cancelAnimationFrame(animId)
-      window.removeEventListener('resize', init)
-    }
-  }, [])
-
-  return <canvas ref={ref} className="fixed inset-0 pointer-events-none" style={{ zIndex: 0 }} />
-}
+import { MeshBackground } from '../components/ui'
 
 /* ── Main ── */
 export default function Setup() {
@@ -174,7 +98,7 @@ export default function Setup() {
 
   return (
     <div className="min-h-screen bg-[#080c14] flex items-center justify-center px-4 py-8 font-[Inter,-apple-system,sans-serif] relative">
-      <NetworkCanvas />
+      <MeshBackground />
 
       <div className="w-full max-w-[420px] relative z-10">
         {/* ── Card ── */}


### PR DESCRIPTION
## Summary

Redesign of the **Agents** page and the **Chat** experience in the dashboard, aligned with the design language already established in **Login** and **Setup** pages.

### Highlights

- **New shared UI primitives** in `components/ui/` — `Card`, `Button`, `Input`, `Label`, `Badge`, `Spinner`, `MeshBackground`. They consolidate the Tailwind class strings that were duplicated across `Login.tsx` and now power the redesign.
- **Reusable `MeshBackground`** extracted from the inline canvas in `Login.tsx`/`Setup.tsx`. Honors `prefers-reduced-motion`. Both pages refactored to consume it.
- **Premium palette** propagated to the Agents page, AgentDetail header/info-rail/view-mode bar, and AgentChat chrome:
  - page background `#0C111D` → `#080c14`
  - card background `#0d1117/#161b22` → `#0b1018/#11182a`
  - borders `#21262d/#30363d` → `#152030/#1e2d3d`
  - muted text `#667085` → `#5a6b7f`
- **Agents page**:
  - Hero header with subtle mesh background (lower density for performance) and gradient fade.
  - Sticky filter bar with backdrop blur.
  - `/` keyboard shortcut focuses search; `X` clears it.
  - Reset-filters CTA in the empty state.
  - `<article>`/`<section>` semantics, `role=\"tab\"`/`role=\"searchbox\"`, focus-visible rings, screen-reader labels for running status.
- **Chat — AgentSwitcher** (the requested feature): a dropdown attached to the agent name in the chat header.
  - Click avatar/name (or press <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd>) opens a panel.
  - Search box, **Recent** group on top, full alphabetical list below.
  - <kbd>↑↓</kbd> navigates, <kbd>Enter</kbd> opens, <kbd>Esc</kbd> closes.
  - Click → \`navigate(/agents/\${name})\`. The existing route already remounts the chat, so session state stays consistent.
  - Locked agents are filtered out automatically.
- **Back-to-Agents** affordance polished with hover slide animation and proper focus ring.

### What was preserved

No behavioural changes to:

- WebSocket lifecycle + HTTP health-check preflight in AgentChat.
- Message streaming, blocks, edit/rewind, copy.
- Approval system + OS Notifications + pending-count callbacks.
- Ticket binding (\`bindTicket\`, \`createAndBindTicket\`).
- Slash-command autocomplete + skills integration.
- File handling (drag-and-drop, base64, previews).
- Recent-agents \`localStorage\` (still uses \`evo:recent-agents\`).
- Active-agents polling (5 s) and notification badge logic.
- Terminal sessions, chat sessions list, rename/archive/delete handlers.
- Profile/Memory tabs in the InfoRail.

### Accessibility

- Semantic landmarks (\`<header>\`, \`<main>\`, \`<aside>\`, \`<section>\`, \`<article>\`).
- ARIA attributes on tablists, tabs, tabpanels, searchboxes, dialogs, listboxes, options.
- Keyboard navigation everywhere (\`/\` for search, \`⌘K\` for switcher, \`↑↓\` lists, \`Esc\` to close, \`Enter\` to confirm).
- \`focus-visible\` ring offsets matching the brand green.
- \`motion-safe:animate-ping\` and \`prefers-reduced-motion\` honoured by the canvas.
- \`sr-only\` labels for status indicators.

### Tests

- \`tsc -b\` passes (no type errors introduced).
- \`vite build\` passes.
- \`eslint\` passes for all touched files in \`src/components/ui\`, \`src/components/chat\`. Existing repo-wide lint warnings on unrelated files are pre-existing and not addressed here.

## Test plan

- [ ] \`/agents\` loads, hero looks right, filter chips work, \`/\` focuses search.
- [ ] Recent strip shows after visiting any agent.
- [ ] Open an agent → header shows clickable avatar + name with chevron.
- [ ] Click the name → switcher opens with Recent + All groups.
- [ ] Search filters the list; <kbd>↑↓ Enter</kbd> works; <kbd>Esc</kbd> closes.
- [ ] <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd> opens the switcher from anywhere on AgentDetail.
- [ ] Selecting another agent navigates to its detail and the chat reconnects.
- [ ] Back link returns to /agents and selection state is preserved.
- [ ] Send a chat message — streaming + tool blocks render unchanged.
- [ ] Trigger a permission approval — modal/inline UI still works.
- [ ] Drag & drop a file — composer accepts and previews.
- [ ] Slash command popup still autocompletes skills.
- [ ] Switch to Terminal mode — terminal tabs and creation still work.
- [ ] Mobile (<lg): drawer toggle opens InfoRail; responsive layout intact.
- [ ] Run with \`prefers-reduced-motion: reduce\` — mesh background does not animate.