### PR TITLE
fix: community issues batch (#35 #45 #46)

### DIFF
--- a/dashboard/frontend/src/components/AgentTerminal.tsx
+++ b/dashboard/frontend/src/components/AgentTerminal.tsx
@@ -42,18 +42,36 @@ const isPrivateHost =
 
 const isLocal = import.meta.env.DEV || isPrivateHost
 
-function deriveWsBase(httpBase: string): string {
-  return httpBase.replace(/^http/i, (m) => (m.toLowerCase() === 'https' ? 'wss' : 'ws'))
+// Resolve an override URL into the (httpBase, wsBase) pair the rest of the
+// component expects. Accepts either http(s):// or ws(s):// — both schemes
+// are mapped to their counterpart so users can paste whichever they have
+// on hand. Invalid input falls back to the heuristic.
+function resolveOverride(raw: string): { http: string; ws: string } | null {
+  try {
+    const u = new URL(raw)
+    const isSecure = u.protocol === 'https:' || u.protocol === 'wss:'
+    const httpProto = isSecure ? 'https:' : 'http:'
+    const wsProto = isSecure ? 'wss:' : 'ws:'
+    const path = u.pathname.replace(/\/+$/, '') + u.search
+    return {
+      http: `${httpProto}//${u.host}${path}`,
+      ws: `${wsProto}//${u.host}${path}`,
+    }
+  } catch {
+    return null
+  }
 }
 
-const CC_WEB_HTTP = terminalOverride
-  ? terminalOverride
+const override = terminalOverride ? resolveOverride(terminalOverride) : null
+
+const CC_WEB_HTTP = override
+  ? override.http
   : isLocal
     ? `http://${hostname}:32352`
     : `${window.location.origin}/terminal`
 
-const CC_WEB_WS = terminalOverride
-  ? deriveWsBase(terminalOverride)
+const CC_WEB_WS = override
+  ? override.ws
   : isLocal
     ? `ws://${hostname}:32352`
     : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/terminal`

--- a/dashboard/frontend/src/components/AgentTerminal.tsx
+++ b/dashboard/frontend/src/components/AgentTerminal.tsx
@@ -11,17 +11,52 @@ interface AgentTerminalProps {
   accentColor?: string
 }
 
-// In dev mode OR local production (localhost/127.0.0.1), connect directly to terminal-server port.
-// In real deployments (behind reverse proxy), use /terminal path on the same origin.
-const isLocal = import.meta.env.DEV || /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname)
+// Terminal connection URL resolution.
+//
+// Default heuristic:
+//   - Dev mode OR a private-network hostname (loopback, RFC1918, RFC6598 CGNAT,
+//     link-local, IPv6 ::1 / fe80:) → connect directly to terminal-server:32352.
+//   - Anything else (public hostname / domain) → use /terminal on the same
+//     origin, assuming a reverse proxy is rewriting the path.
+//
+// Escape hatch for mixed scenarios (e.g. reverse proxy sitting in front of a
+// private IP): set VITE_TERMINAL_URL at build time to force a specific base
+// URL. When set, it overrides the heuristic entirely. Trailing slash is
+// stripped so both `https://x.y/terminal` and `https://x.y/terminal/` work.
+const rawOverride = (import.meta.env.VITE_TERMINAL_URL as string | undefined)?.trim()
+const terminalOverride = rawOverride ? rawOverride.replace(/\/+$/, '') : null
 
-const CC_WEB_HTTP = isLocal
-  ? `http://${window.location.hostname}:32352`
-  : `${window.location.origin}/terminal`
+const hostname = window.location.hostname
+const isPrivateHost =
+  /^localhost$/i.test(hostname) ||
+  /^127\./.test(hostname) ||
+  /^10\./.test(hostname) ||
+  /^192\.168\./.test(hostname) ||
+  /^169\.254\./.test(hostname) ||
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname) ||
+  /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./.test(hostname) || // RFC6598 CGNAT
+  hostname === '::1' ||
+  /^\[::1\]$/.test(hostname) ||
+  /^fe80:/i.test(hostname) ||
+  /^\[fe80:/i.test(hostname)
 
-const CC_WEB_WS = isLocal
-  ? `ws://${window.location.hostname}:32352`
-  : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/terminal`
+const isLocal = import.meta.env.DEV || isPrivateHost
+
+function deriveWsBase(httpBase: string): string {
+  return httpBase.replace(/^http/i, (m) => (m.toLowerCase() === 'https' ? 'wss' : 'ws'))
+}
+
+const CC_WEB_HTTP = terminalOverride
+  ? terminalOverride
+  : isLocal
+    ? `http://${hostname}:32352`
+    : `${window.location.origin}/terminal`
+
+const CC_WEB_WS = terminalOverride
+  ? deriveWsBase(terminalOverride)
+  : isLocal
+    ? `ws://${hostname}:32352`
+    : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/terminal`
 
 type Status = 'connecting' | 'ready' | 'starting' | 'running' | 'error' | 'exited'
 

--- a/dashboard/frontend/src/pages/Knowledge/Connections/Wizard.tsx
+++ b/dashboard/frontend/src/pages/Knowledge/Connections/Wizard.tsx
@@ -258,6 +258,14 @@ export default function Wizard({ onClose, onCreated }: Props) {
                     onChange={(e) => set('connection_string', e.target.value)}
                     className="w-full bg-[#182230] border border-[#344054] rounded-lg px-3 py-2 text-sm text-[#F9FAFB] placeholder-[#667085] focus:border-[#00FFA7] focus:outline-none font-mono"
                   />
+                  <p className="mt-2 text-[11px] text-[#667085] leading-relaxed">
+                    Using <strong>Supabase / Neon / Railway</strong>? Use the <em>direct</em>{' '}
+                    connection string on port <code className="text-[#D0D5DD]">5432</code>, not the
+                    transaction pooler on <code className="text-[#D0D5DD]">6543</code>. Transaction
+                    pooling (PgBouncer) breaks Alembic migrations,{' '}
+                    <code className="text-[#D0D5DD]">CREATE INDEX … USING hnsw</code>, and
+                    SQLAlchemy prepared statements. Session pooler works if you need pooling.
+                  </p>
                 </div>
               ) : (
                 <div className="grid grid-cols-2 gap-3">

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,0 +1,114 @@
+# ============================================================================
+# EvoNexus — docker-compose para instalações atrás de reverse proxy
+#
+# Use este arquivo em vez de docker-compose.hub.yml quando o host já tiver um
+# reverse proxy na frente cuidando do TLS e do roteamento externo — por
+# exemplo: Coolify, Dokploy, Traefik, Caddy, Nginx Proxy Manager.
+#
+# Diferença principal: as portas do dashboard e do terminal-server são
+# declaradas como `expose` (só alcançáveis dentro da rede Docker) em vez de
+# `ports` (mapeadas no host). Isso evita conflito com o proxy que já ocupa
+# 80/443/8080 no host e mantém toda a comunicação externa sob controle do
+# proxy.
+#
+# Requisitos:
+#   - Seu reverse proxy precisa estar na mesma rede Docker que os serviços
+#     abaixo (ou ter acesso a ela). A maioria das ferramentas (Coolify,
+#     Dokploy, Traefik) faz isso automaticamente.
+#   - Roteie 2 rotas públicas pro container `dashboard`:
+#       1. `/`          → porta 8080   (UI + API HTTP)
+#       2. `/terminal`  → porta 32352  (terminal-server, HTTP + WebSocket upgrade)
+#     Alternativamente, publique o terminal em subdomínio separado e use a
+#     env var VITE_TERMINAL_URL (veja README.md) no build do frontend.
+#
+# Uso:
+#   $ curl -O https://raw.githubusercontent.com/EvolutionAPI/evo-nexus/main/docker-compose.proxy.yml
+#   $ docker compose -f docker-compose.proxy.yml up -d
+#
+# Para instalações simples em localhost ou VPS sem reverse proxy,
+# continue usando docker-compose.hub.yml.
+# ============================================================================
+
+services:
+  # Dashboard — Flask + React + terminal embutido + Claude CLI.
+  # Portas expostas apenas dentro da rede Docker; o reverse proxy é quem
+  # publica para o mundo externo.
+  dashboard:
+    image: evoapicloud/evo-nexus-dashboard:latest
+    container_name: evonexus-dashboard
+    expose:
+      - "8080"    # Dashboard (UI + API)
+      - "32352"   # Terminal server (WebSocket)
+    environment:
+      - TZ=America/Sao_Paulo
+      - EVONEXUS_PORT=8080
+      - TERMINAL_SERVER_PORT=32352
+      - FORWARDED_ALLOW_IPS=*
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_dashboard_data:/workspace/dashboard/data
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Telegram — bot que escuta mensagens e delega para agentes.
+  # Opcional: remova este serviço se não for usar Telegram.
+  telegram:
+    image: evoapicloud/evo-nexus-runtime:latest
+    container_name: evonexus-telegram
+    command: ["claude", "--channels", "plugin:telegram@claude-plugins-official", "--dangerously-skip-permissions"]
+    environment:
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    depends_on:
+      dashboard:
+        condition: service_healthy
+
+  # Scheduler — executa rotinas automáticas (daily, weekly, monthly).
+  # Opcional: remova este serviço se não for usar rotinas automatizadas.
+  scheduler:
+    image: evoapicloud/evo-nexus-runtime:latest
+    container_name: evonexus-scheduler
+    command: ["uv", "run", "python", "scheduler.py"]
+    environment:
+      - TZ=America/Sao_Paulo
+      - REQUIRE_ANTHROPIC_KEY=1
+    volumes:
+      - evonexus_config:/workspace/config
+      - evonexus_workspace:/workspace/workspace
+      - evonexus_memory:/workspace/memory
+      - evonexus_adw_logs:/workspace/ADWs/logs
+      - evonexus_agent_memory:/workspace/.claude/agent-memory
+    restart: unless-stopped
+    depends_on:
+      dashboard:
+        condition: service_healthy
+
+# ----------------------------------------------------------------------------
+# Volumes nomeados — mesmos de docker-compose.hub.yml. Você pode migrar de um
+# arquivo para o outro sem perder dados: os volumes são resolvidos por nome.
+# ----------------------------------------------------------------------------
+volumes:
+  evonexus_config:
+  evonexus_workspace:
+  evonexus_dashboard_data:
+  evonexus_memory:
+  evonexus_adw_logs:
+  evonexus_agent_memory:

--- a/docs/knowledge-database.md
+++ b/docs/knowledge-database.md
@@ -1,0 +1,88 @@
+# Knowledge — database setup
+
+The Knowledge base stores chunked documents with vector embeddings in
+PostgreSQL + pgvector. This page collects the gotchas you need to know
+before pointing it at a managed database.
+
+## Requirements
+
+- **PostgreSQL 14+** with the `pgvector` extension available.
+- **Session mode** connections. Transaction pooling (PgBouncer in
+  transaction-pooling mode) is **not supported**, see below.
+- Privileges sufficient to run `CREATE EXTENSION IF NOT EXISTS vector`,
+  `CREATE INDEX ... USING hnsw`, and Alembic migrations on first connect.
+
+## Provider cheat-sheet
+
+### Supabase
+
+Supabase exposes **two** Postgres endpoints per project:
+
+| Endpoint                                         | Port | Mode              | Use here? |
+|--------------------------------------------------|------|-------------------|-----------|
+| Direct connection (`db.<ref>.supabase.co`)       | 5432 | Session           | **Yes**   |
+| Pooler (`aws-*-*.pooler.supabase.com`)           | 6543 | Transaction pool  | **No**    |
+| Session pooler (`aws-*-*.pooler.supabase.com`)   | 5432 | Session           | Yes       |
+
+Use the direct connection string Supabase shows in
+*Project Settings → Database → Connection string → URI*. It looks like:
+
+```
+postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres
+```
+
+If you pasted the pooler URL (port `6543` or hostname containing `pooler`)
+the wizard fails fast with a `Knowledge is not compatible with PgBouncer
+in transaction pooling mode` error. That's by design — the Alembic
+migrations and `CREATE INDEX ... USING hnsw` statements rely on prepared
+statements and session-scoped state that PgBouncer's transaction pooling
+silently drops.
+
+If you genuinely need pooling (for example, your Supabase project is on
+a plan with a connection limit), use the **session pooler** endpoint
+Supabase exposes on port `5432`. It keeps prepared statements working
+while still bounding the number of backend connections.
+
+#### IPv6-only direct connection
+
+New Supabase projects default to IPv6-only on the direct endpoint. If
+your host does not have IPv6 connectivity the connection will fail with
+
+```
+connection to server at "db.<ref>.supabase.co" failed: Network is unreachable
+```
+
+Workarounds:
+
+1. Enable the IPv4 add-on in Supabase (paid feature).
+2. Use the session pooler URL on port `5432` — it is dual-stack.
+3. Run Knowledge on a host with native IPv6 (most cloud providers do).
+
+### Neon, Railway, Render, Fly, Heroku
+
+Same rule: give Knowledge the **session-mode** connection string. Neon
+and Railway both expose a pooler; pick the non-pooler URL from the
+dashboard. The fast-fail check triggers on port `6543` and on hostnames
+containing `pooler`.
+
+### Self-hosted Postgres
+
+Nothing special — just make sure `pgvector` is installed
+(`CREATE EXTENSION vector` runs as superuser or owner of the target
+database) and that the user in your connection string can create
+extensions and indexes.
+
+## Error reference
+
+| Message snippet                                  | Cause                                                 | Fix |
+|--------------------------------------------------|-------------------------------------------------------|-----|
+| `hostname contains 'pooler'`                     | You pasted the Supabase/Neon transaction-pool URL     | Swap for the direct (`5432`) connection string |
+| `port 6543 (Supabase transaction pooler)`        | Same as above, detected by port                        | Same |
+| `Network is unreachable` + IPv6 address          | Host has no IPv6, direct endpoint is IPv6-only        | Session pooler URL or IPv4 add-on |
+| `could not load extension "vector"`              | pgvector not installed on the cluster                  | `CREATE EXTENSION vector;` as a role with privileges |
+| `permission denied to create extension "vector"` | Role lacks `CREATE` on the database                   | Grant it, or run the `CREATE EXTENSION` yourself |
+
+## Related
+
+- Wizard: **Knowledge → Connections → New** in the dashboard.
+- Source for the validation: `dashboard/backend/knowledge/auto_migrator.py`.


### PR DESCRIPTION
## Summary

Three community-reported issues bundled into one PR. Each is a small,
independent change; grouped because they all land on community
friction points and share review context.

- **#35** — Terminal fails to connect on bare-metal VPS with private-IP
  access. Widen the "is local" heuristic to cover RFC1918, RFC6598
  (CGNAT, common on Brazilian VPS), and IPv6 loopback/link-local. Also
  introduce `VITE_TERMINAL_URL` as an explicit override for the
  reverse-proxy-on-private-IP edge case.

- **#45** — Port collision with reverse proxies (Coolify, Dokploy,
  Traefik). Add `docker-compose.proxy.yml` variant using `expose:`
  instead of `ports:` so the reverse proxy owns external publishing.
  Same service graph, same named volumes — users can migrate without
  data loss. `docker-compose.hub.yml` untouched.

- **#46** — Supabase Knowledge 409 on pooler URL. The backend guard in
  `auto_migrator.py` already catches this, but the message only
  appears after submit. Add an inline hint in the connection wizard
  (naming Supabase / Neon / Railway) and a new `docs/knowledge-database.md`
  with a provider cheat-sheet + error reference.

## What I explicitly didn't do

- **#19 partial (telegram `user: "1000:1000"`)** — considered, then
  pulled. The dashboard image still runs as root, so pinning only
  telegram/scheduler to UID 1000 creates a cross-container permission
  split on shared named volumes and could break existing installs on
  upgrade. Better tackled after the runtime/dashboard images
  consistently ship a non-root user.

## Test plan

- [x] `tsc --noEmit` on the frontend — clean
- [x] `docker compose -f docker-compose.proxy.yml config` — valid
- [x] `docker compose -f docker-compose.hub.yml config` — valid (no regression)
- [ ] Manual: access dashboard via `http://<RFC1918>:8686` on bare-metal
      bare-metal → terminal connects to `:32352` directly
- [ ] Manual: access via `localhost` / `127.0.0.1` → no regression
- [ ] Manual: `docker compose -f docker-compose.proxy.yml up -d` behind
      Traefik / Coolify → UI reachable via proxy
- [ ] Manual: paste a Supabase pooler URL in the Knowledge wizard →
      inline hint visible *before* submit

## Issues

- Closes #35
- Closes #45
- Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address terminal connectivity, reverse proxy deployment, and managed Postgres pooler usability issues reported by the community.

New Features:
- Introduce a configurable VITE_TERMINAL_URL override to explicitly control the terminal server base URL in mixed or reverse-proxy setups.
- Add docker-compose.proxy.yml to support deployments behind existing reverse proxies using exposed ports instead of host-mapped ports.
- Add inline guidance in the Knowledge connection wizard about using direct session-mode Postgres URLs for providers like Supabase, Neon, and Railway.
- Add a dedicated knowledge-database.md guide covering managed Postgres/pgvector setup, provider-specific pooler behavior, and common error cases.

Bug Fixes:
- Expand the frontend terminal "is local" heuristic to cover private IPv4 ranges, CGNAT, and IPv6 loopback/link-local hosts so terminals connect correctly on private-IP VPS installs.
- Clarify and prevent misconfiguration with Supabase/Neon/Railway transaction poolers that cause Knowledge migrations to fail by surfacing guidance directly in the UI and docs.