### PR TITLE
feat(security): rate-limit public share endpoint + security headers

### DIFF
--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -93,6 +93,12 @@ except AttributeError:
 
 CORS(app, origins=_cors_allowed_origins(), supports_credentials=True)
 
+# --------------- Rate limiting (in-memory, single-process Flask) ---------------
+# Vault audit §2.S1 CRITICAL: all public endpoints require rate limiting.
+# The limiter singleton lives in rate_limit.py to avoid circular imports with blueprints.
+from rate_limit import limiter
+limiter.init_app(app)
+
 # --------------- Database ---------------
 from models import db, User, BrainRepoConfig, needs_setup, seed_roles, seed_systems
 db.init_app(app)

--- a/dashboard/backend/rate_limit.py
+++ b/dashboard/backend/rate_limit.py
@@ -1,0 +1,26 @@
+"""Shared Flask-Limiter instance for EvoNexus.
+
+Placing the limiter here (rather than in app.py directly) breaks the
+circular-import chain: app.py initialises it, route blueprints import it.
+
+Usage in a blueprint::
+
+    from rate_limit import limiter
+
+    @bp.route("/api/shares/<token>/view")
+    @limiter.limit("60 per minute")
+    def view_share(token: str):
+        ...
+"""
+
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# Uninitialised instance — app.py calls limiter.init_app(app) at startup.
+limiter = Limiter(
+    get_remote_address,
+    # Default: generous to avoid false positives on authenticated API routes.
+    # Individual endpoints override with @limiter.limit() decorators.
+    default_limits=["600 per minute"],
+    storage_uri="memory://",
+)

--- a/dashboard/backend/routes/shares.py
+++ b/dashboard/backend/routes/shares.py
@@ -5,10 +5,11 @@ import secrets
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request, Response
+from flask import Blueprint, jsonify, request, Response, after_this_request
 from flask_login import login_required, current_user
 
 from models import db, FileShare, audit, has_workspace_folder_access
+from rate_limit import limiter
 from routes.auth_routes import require_permission
 
 bp = Blueprint("shares", __name__)
@@ -184,6 +185,7 @@ def revoke_share(token: str):
 # ── Public endpoint (no auth required) ──────────────────────────────────────
 
 @bp.route("/api/shares/<token>/view", methods=["GET"])
+@limiter.limit("60 per minute")
 def view_share(token: str):
     """Serve the file content for a valid share token. No authentication required."""
     share = FileShare.query.filter_by(token=token).first()
@@ -213,6 +215,16 @@ def view_share(token: str):
     ip = request.remote_addr or "-"
     ua = (request.headers.get("User-Agent", "-") or "-")[:200]
     audit(None, "share_view", "shares", detail=f"token={token} ip={ip} ua={ua[:80]}")
+
+    # Vault §2.S2: security headers on all public share responses.
+    @after_this_request
+    def _add_security_headers(response):
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Cache-Control"] = "no-store, private, no-cache, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+        return response
 
     suffix = full.suffix.lower()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "watchdog>=4.0",
     "sqlparse>=0.4,<1.0",
     "jsonschema>=4.21",
+    "flask-limiter>=3.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- **Vault §2.S1 CRITICAL**: add `flask-limiter` (in-memory, single-process) — `60 req/min/IP` on `/api/shares/<token>/view`
- **Vault §2.S2**: inject `Referrer-Policy: no-referrer`, `Cache-Control: no-store`, `Pragma: no-cache`, `HSTS`, `X-Content-Type-Options` on every public share response
- Add `flask-limiter>=3.5` to `pyproject.toml` dependencies
- Create `dashboard/backend/rate_limit.py` singleton (breaks circular-import between `app.py` → blueprints)
- Global default 600 req/min on all routes; sensitive endpoints override with `@limiter.limit()`

## Test plan

- [ ] 71 existing backend tests pass (excluding pre-existing `test_cache_hit_does_not_call_compute_again` failure unrelated to this PR)
- [ ] Manual: 61st request in 1 min to `/api/shares/<token>/view` → HTTP 429 + `Retry-After` header
- [ ] Manual: share response includes all 5 security headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce request rate limiting and stricter security headers for public share endpoints.

New Features:
- Add rate limiting to the public file share view endpoint to cap requests per IP address.
- Introduce a shared Flask-Limiter instance with a default global rate limit for all routes.

Enhancements:
- Apply standard security headers to all public share responses to improve caching, referrer, content-type, and transport security.
- Add flask-limiter as a new backend dependency.