### PR TITLE
feat(plugins): writable_data requires_role + readonly_data current_user auto-injection

### DIFF
--- a/dashboard/backend/plugin_schema.py
+++ b/dashboard/backend/plugin_schema.py
@@ -577,6 +577,14 @@ class PluginWritableResource(BaseModel):
     )
     # Optional JSON Schema for payload validation (jsonschema library)
     json_schema: Optional[WritableResourceJsonSchema] = None
+    # Wave 2.1.x: optional endpoint-level RBAC. When set, only authenticated
+    # users whose ``current_user.role`` is in this list may POST/PUT/DELETE this
+    # resource.  Empty/None means any authenticated user passes (legacy default).
+    # Role 'admin' always passes regardless of the list (super-user override).
+    # Plugins use this to gate writable resources by role without needing a host
+    # PR or app-layer wrapper.  See evonexus-plugin-nutri for split-endpoint
+    # patterns (patients_admin vs patients_clinical).
+    requires_role: Optional[List[Annotated[str, Field(min_length=1, max_length=64)]]] = None
 
     @field_validator("id")
     @classmethod
@@ -594,6 +602,18 @@ class PluginWritableResource(BaseModel):
             raise ValueError(
                 f"WritableResource table '{v}' must match ^[a-z][a-z0-9_]*$"
             )
+        return v
+
+    @field_validator("requires_role")
+    @classmethod
+    def requires_role_pattern(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is None:
+            return v
+        for role in v:
+            if not re.match(r"^[a-z][a-z0-9-]*$", role):
+                raise ValueError(
+                    f"requires_role entry '{role}' must match ^[a-z][a-z0-9-]*$ (kebab-case)"
+                )
         return v
 
 

--- a/dashboard/backend/routes/plugins.py
+++ b/dashboard/backend/routes/plugins.py
@@ -2121,10 +2121,17 @@ def readonly_data(slug: str, query_name: str):
     if not sql:
         return jsonify({"error": "Invalid query declaration"}), 500
 
-    # Build query params from request.args — only declared params allowed
+    # Build query params from request.args — only declared params allowed.
+    # Wave 2.1.x reserved params (current_user_id, current_user_role) are
+    # injected server-side below and MUST NOT come from the client.
+    _RESERVED_PARAMS = {"current_user_id", "current_user_role"}
     declared_params = query_decl.get("params", {})
     params: dict = {}
     for key, value in request.args.items():
+        if key in _RESERVED_PARAMS:
+            return jsonify({
+                "error": f"Parameter '{key}' is reserved and cannot be supplied by the client"
+            }), 400
         if key not in declared_params:
             return jsonify({"error": f"Parameter '{key}' not declared in manifest"}), 400
         params[key] = value
@@ -2145,6 +2152,15 @@ def readonly_data(slug: str, query_name: str):
             params["limit"] = 1000
     elif ":limit" in sql:
         params["limit"] = 1000
+
+    # Wave 2.1.x — auto-inject current_user identity bind params (Gap 5 fix
+    # from evonexus-plugin-nutri Step 3). Plugins reference these as
+    # :current_user_id and :current_user_role in their SQL to enforce
+    # server-side scoping (e.g. `WHERE primary_nutritionist_id = :current_user_id`).
+    # These keys are reserved — manifest params with the same name are
+    # silently overridden.  Always present, regardless of declaration.
+    params["current_user_id"] = getattr(current_user, "id", None)
+    params["current_user_role"] = getattr(current_user, "role", "viewer")
 
     try:
         conn = _get_db()
@@ -2226,6 +2242,19 @@ def writable_data(slug: str, resource_id: str):
             table, slug_under,
         )
         return jsonify({"error": "Internal manifest error"}), 500
+
+    # Wave 2.1.x — endpoint-level RBAC enforcement (Gap 1 fix from
+    # evonexus-plugin-nutri Step 3 RBAC decision). When requires_role is set
+    # in the manifest, only users whose role is in the list may mutate.
+    # 'admin' always passes (super-user override).
+    requires_role = resource_decl.get("requires_role")
+    if requires_role:
+        actor_role = getattr(current_user, "role", "viewer")
+        if actor_role != "admin" and actor_role not in requires_role:
+            return jsonify({
+                "error": f"Resource '{resource_id}' requires role in {requires_role}, "
+                         f"current role is '{actor_role}'"
+            }), 403
 
     allowed_columns: list[str] = resource_decl.get("allowed_columns") or []
     method = request.method

--- a/tests/backend/test_plugins_rbac_and_scoping.py
+++ b/tests/backend/test_plugins_rbac_and_scoping.py
@@ -1,0 +1,303 @@
+"""Wave 2.1.x — endpoint-level RBAC + readonly auto-scoping tests.
+
+Covers:
+- PluginWritableResource accepts requires_role list (Pydantic validator)
+- requires_role rejects bad role names
+- writable_data handler returns 403 when role mismatch
+- writable_data handler accepts when role matches OR user is 'admin'
+- readonly_data auto-injects current_user_id and current_user_role
+- readonly_data rejects client-supplied current_user_id (reserved param)
+- backwards-compat: resources without requires_role still work for any user
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "dashboard" / "backend"
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema tests — requires_role field
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresRoleSchema:
+    def test_writable_resource_accepts_requires_role(self):
+        from plugin_schema import PluginWritableResource
+        r = PluginWritableResource(
+            id="patients_clinical",
+            description="Clinical fields — nutri only",
+            table="nutri_patients",
+            allowed_columns=["goal", "consent_given_at"],
+            requires_role=["nutricionista", "nutri-admin"],
+        )
+        assert r.requires_role == ["nutricionista", "nutri-admin"]
+
+    def test_writable_resource_requires_role_optional(self):
+        from plugin_schema import PluginWritableResource
+        r = PluginWritableResource(
+            id="open_resource",
+            description="No RBAC — backwards compatible",
+            table="nutri_brand_settings",
+            allowed_columns=["office_name"],
+        )
+        assert r.requires_role is None
+
+    def test_writable_resource_rejects_bad_role_name(self):
+        from plugin_schema import PluginWritableResource
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            PluginWritableResource(
+                id="test",
+                description="x",
+                table="nutri_test",
+                allowed_columns=["x"],
+                requires_role=["Nutri Admin"],  # uppercase + space — should fail
+            )
+
+    def test_writable_resource_accepts_kebab_case_role(self):
+        from plugin_schema import PluginWritableResource
+        r = PluginWritableResource(
+            id="t",
+            description="x",
+            table="nutri_test",
+            allowed_columns=["x"],
+            requires_role=["nutri-admin", "super-user", "viewer"],
+        )
+        assert r.requires_role == ["nutri-admin", "super-user", "viewer"]
+
+
+# ---------------------------------------------------------------------------
+# Flask app + handlers tests — RBAC enforcement + readonly auto-scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Temp SQLite DB with users + plugins_installed + a fake nutri_test table."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY, username TEXT, role TEXT NOT NULL DEFAULT 'viewer'
+        );
+        INSERT INTO users (id, username, role) VALUES
+            (1, 'alice', 'nutricionista'),
+            (2, 'bob',   'recepcao'),
+            (3, 'admin', 'admin');
+        CREATE TABLE plugins_installed (
+            slug TEXT PRIMARY KEY, enabled INTEGER, status TEXT,
+            capabilities_disabled TEXT
+        );
+        INSERT INTO plugins_installed (slug, enabled, status, capabilities_disabled)
+            VALUES ('nutri', 1, 'active', '{}');
+        CREATE TABLE nutri_test (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            owner_id INTEGER
+        );
+        INSERT INTO nutri_test (name, owner_id) VALUES
+            ('Alice patient', 1),
+            ('Alice patient 2', 1),
+            ('Bob patient', 2);
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def app(tmp_path, tmp_db):
+    """Flask app with plugins blueprint + a fake installed plugin manifest on disk."""
+    import flask
+    from flask_login import LoginManager
+
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "nutri"
+    plugin_dir.mkdir(parents=True)
+
+    manifest = {
+        "manifest": {
+            "id": "nutri",
+            "writable_data": [
+                {
+                    "id": "test_open",
+                    "description": "open",
+                    "table": "nutri_test",
+                    "allowed_columns": ["name", "owner_id"],
+                },
+                {
+                    "id": "test_clinical",
+                    "description": "clinical",
+                    "table": "nutri_test",
+                    "allowed_columns": ["name", "owner_id"],
+                    "requires_role": ["nutricionista", "nutri-admin"],
+                },
+            ],
+            "readonly_data": [
+                {
+                    "id": "my_rows",
+                    "description": "rows owned by current user",
+                    "sql": "SELECT id, name FROM nutri_test WHERE owner_id = :current_user_id ORDER BY id",
+                },
+                {
+                    "id": "all_rows",
+                    "description": "all rows",
+                    "sql": "SELECT id, name, owner_id FROM nutri_test ORDER BY id",
+                },
+            ],
+        }
+    }
+    (plugin_dir / ".install-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    # Patch PLUGINS_DIR + _get_db before importing the blueprint
+    import routes.plugins as plugins_mod
+    plugins_mod.PLUGINS_DIR = plugins_root
+
+    def _get_db_override():
+        c = sqlite3.connect(str(tmp_db))
+        c.row_factory = sqlite3.Row
+        return c
+    plugins_mod._get_db = _get_db_override
+
+    from routes.plugins import bp as plugins_bp
+
+    flask_app = flask.Flask(__name__)
+    flask_app.config["TESTING"] = True
+    flask_app.config["SECRET_KEY"] = "test"
+
+    lm = LoginManager()
+    lm.init_app(flask_app)
+
+    class FakeUser:
+        is_authenticated = True
+        is_active = True
+        is_anonymous = False
+        def __init__(self, uid, role):
+            self.id = uid
+            self.username = f"user{uid}"
+            self.role = role
+        def get_id(self):
+            return str(self.id)
+
+    flask_app._fake_user = None  # set per test
+
+    @lm.user_loader
+    def loader(uid):
+        return flask_app._fake_user if flask_app._fake_user else None
+
+    @lm.unauthorized_handler
+    def unauthorized():
+        return flask.jsonify({"error": "auth required"}), 401
+
+    flask_app.register_blueprint(plugins_bp)
+    flask_app._FakeUser = FakeUser
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def login_as(app, client, uid, role):
+    app._fake_user = app._FakeUser(uid, role)
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(uid)
+        sess["_fresh"] = True
+
+
+# ── writable_data RBAC ─────────────────────────────────────────────────────
+
+class TestWritableDataRbac:
+    def test_open_resource_accepts_any_role(self, app, client):
+        """Resource without requires_role works for recepcao (backwards compat)."""
+        login_as(app, client, 2, "recepcao")
+        resp = client.post(
+            "/api/plugins/nutri/data/test_open",
+            json={"name": "new", "owner_id": 2},
+        )
+        assert resp.status_code in (200, 201), resp.get_json()
+
+    def test_clinical_resource_rejects_recepcao(self, app, client):
+        """requires_role=[nutricionista,nutri-admin] → recepcao gets 403."""
+        login_as(app, client, 2, "recepcao")
+        resp = client.post(
+            "/api/plugins/nutri/data/test_clinical",
+            json={"name": "leaked", "owner_id": 2},
+        )
+        assert resp.status_code == 403
+        body = resp.get_json()
+        assert "requires role" in body["error"].lower()
+
+    def test_clinical_resource_accepts_nutricionista(self, app, client):
+        """requires_role=[nutricionista,nutri-admin] → nutricionista passes."""
+        login_as(app, client, 1, "nutricionista")
+        resp = client.post(
+            "/api/plugins/nutri/data/test_clinical",
+            json={"name": "ok", "owner_id": 1},
+        )
+        assert resp.status_code in (200, 201), resp.get_json()
+
+    def test_clinical_resource_admin_override(self, app, client):
+        """role='admin' always passes (super-user override)."""
+        login_as(app, client, 3, "admin")
+        resp = client.post(
+            "/api/plugins/nutri/data/test_clinical",
+            json={"name": "by-admin", "owner_id": 3},
+        )
+        assert resp.status_code in (200, 201), resp.get_json()
+
+
+# ── readonly_data auto-scoping ─────────────────────────────────────────────
+
+class TestReadonlyAutoScoping:
+    def test_current_user_id_injected(self, app, client):
+        """SQL with :current_user_id returns only user 1's rows."""
+        login_as(app, client, 1, "nutricionista")
+        resp = client.get("/api/plugins/nutri/readonly-data/my_rows")
+        assert resp.status_code in (200, 201), resp.get_json()
+        rows = resp.get_json()["rows"]
+        assert len(rows) == 2  # Alice has 2 rows
+        assert all(r["name"].startswith("Alice") for r in rows)
+
+    def test_current_user_id_changes_per_user(self, app, client):
+        """Different user → different rows scoped automatically."""
+        login_as(app, client, 2, "recepcao")
+        resp = client.get("/api/plugins/nutri/readonly-data/my_rows")
+        rows = resp.get_json()["rows"]
+        assert len(rows) == 1  # Bob has 1 row
+        assert rows[0]["name"] == "Bob patient"
+
+    def test_client_cannot_spoof_current_user_id(self, app, client):
+        """?current_user_id=2 from client → 400, identity is server-only."""
+        login_as(app, client, 1, "nutricionista")
+        resp = client.get("/api/plugins/nutri/readonly-data/my_rows?current_user_id=2")
+        assert resp.status_code == 400
+        assert "reserved" in resp.get_json()["error"].lower()
+
+    def test_client_cannot_spoof_current_user_role(self, app, client):
+        login_as(app, client, 2, "recepcao")
+        resp = client.get(
+            "/api/plugins/nutri/readonly-data/all_rows?current_user_role=admin"
+        )
+        assert resp.status_code == 400
+        assert "reserved" in resp.get_json()["error"].lower()
+
+    def test_query_without_current_user_ref_still_works(self, app, client):
+        """Backwards compat — queries that don't reference :current_user_id work fine."""
+        login_as(app, client, 1, "nutricionista")
+        resp = client.get("/api/plugins/nutri/readonly-data/all_rows")
+        assert resp.status_code == 200
+        rows = resp.get_json()["rows"]
+        assert len(rows) == 3  # all rows visible


### PR DESCRIPTION
## Summary

Two related Wave 2.1.x extensions to the plugin contract closing the last two gaps blocking endpoint-level RBAC for plugin authors. Discovered during evonexus-plugin-nutri Step 3 RBAC decision (split `patients_admin` vs `patients_clinical` was needed because the host had no role gate per endpoint).

- **Gap 1** — `PluginWritableResource.requires_role: Optional[List[str]]` field. Handler returns 403 when `current_user.role` is not in the list. `'admin'` always passes (super-user override).
- **Gap 5** — `readonly_data` auto-injects `:current_user_id` and `:current_user_role` as bind params on every query. Plugins reference them in SQL for server-enforced scoping. Both names are reserved — client requests carrying them in query string get 400 (no identity spoofing).

## Why

Before this PR, plugin authors had two unsafe options for role-based access:
1. Enforce in the UI only — anyone with curl bypasses
2. Split a single resource into N endpoints by role (workaround used in `evonexus-plugin-nutri` `patients_admin` vs `patients_clinical`) — duplicates schema and still doesn't gate the endpoints themselves

For `readonly_data`, the only scoping option was to declare a `nutritionist_id` param and hope the UI supplies it correctly — `curl ?` gets the unfiltered set.

This PR closes both with ~25 lines of host code.

## Compat

- Existing plugins (PM Essentials) work unchanged. `requires_role` defaults to `None` (any auth user passes). Auto-injected bind params are silently ignored if SQL doesn't reference them.
- Reserved-param guard is the only behavioural change visible to existing clients — but no plugin in the marketplace uses `current_user_id` or `current_user_role` as a query-string param today.

## Test plan

- [x] 13 new pytest cases in `tests/backend/test_plugins_rbac_and_scoping.py`
  - Pydantic accepts/rejects requires_role correctly (kebab-case validator)
  - 403 path: clinical resource + recepcao role
  - 200/201 path: clinical resource + nutricionista role
  - admin override: clinical resource + admin role
  - Open resource (no requires_role): any role passes
  - readonly auto-inject: scoped result per-user
  - readonly spoofing: client `?current_user_id=2` returns 400
  - Backwards compat: query without `:current_user_id` ref still returns all rows
- [x] Pre-existing `tests/backend/` suite: 91 passed (2 unrelated cache-test failures pre-existing — `_compute_preview` signature drift in `test_plugins_preview_endpoint.py`)
- [x] Plugin nutri full regression after consuming the new field on 6 writable resources: 14/14 install ACs + 89 pytest + 9/9 yaml validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)