### PR TITLE
fix(plugins): Skip scan now actually skips — no more silent gate-blocking

### DIFF
--- a/dashboard/frontend/src/components/PluginInstallModal.tsx
+++ b/dashboard/frontend/src/components/PluginInstallModal.tsx
@@ -44,6 +44,9 @@ export default function PluginInstallModal({ onClose, onInstalled }: Props) {
   const [, setScanResult] = useState<ScanResult | null>(null)
   const [overrideReason, setOverrideReason] = useState('')
   const [warnConfirmed, setWarnConfirmed] = useState(false)
+  // Optional reason captured when admin checks "Skip scan" — never required;
+  // backend audit logs the skip regardless.
+  const [skipReason, setSkipReason] = useState('')
 
   // Effective source: uploaded staged path wins over URL input
   const effectiveSource = () => (uploadedPath ?? sourceUrl.trim())
@@ -62,12 +65,15 @@ export default function PluginInstallModal({ onClose, onInstalled }: Props) {
   }, [])
 
   // Scan gate logic (mirrors UpdatePreviewModal):
-  // null = scan not yet completed (wait) | APPROVE = pass | WARN+confirmed = pass |
-  // BLOCK+overrideReason(≥20) = admin pass
+  //   null    = scan not yet completed (wait)
+  //   APPROVE = pass
+  //   WARN    = pass when checkbox confirmed
+  //   BLOCK   = pass when admin types a ≥20-char override reason
+  //   SKIPPED = pass immediately (admin chose to bypass; audit logs the action)
   const scanGatePassed =
     scanVerdict === null
       ? false // still scanning
-      : scanVerdict === 'APPROVE'
+      : scanVerdict === 'APPROVE' || scanVerdict === 'SKIPPED'
         ? true
         : scanVerdict === 'WARN'
           ? warnConfirmed
@@ -129,6 +135,12 @@ export default function PluginInstallModal({ onClose, onInstalled }: Props) {
       if (scanVerdict === 'WARN' && warnConfirmed) body.confirmed_verdict = 'WARN'
       if (scanVerdict === 'BLOCK' && overrideReason.trim().length >= 20) {
         body.override_reason = overrideReason.trim()
+      }
+      // SKIPPED — admin bypassed the scan; backend audit-logs both the skip
+      // and the optional reason.
+      if (scanVerdict === 'SKIPPED') {
+        body.skip_scan = true
+        if (skipReason.trim()) body.skip_reason = skipReason.trim()
       }
       const result = await api.post('/plugins/install', body) as { slug: string; mcp_servers_installed?: Array<{ effective_name: string }> }
       setInstalledSlug(result.slug)
@@ -284,6 +296,7 @@ export default function PluginInstallModal({ onClose, onInstalled }: Props) {
                 authToken={authToken.trim() || undefined}
                 onVerdict={handleScanVerdict}
                 onOverride={handleOverride}
+                onSkipReason={setSkipReason}
               />
 
               {/* WARN confirmation checkbox */}

--- a/dashboard/frontend/src/components/SecurityScanSection.tsx
+++ b/dashboard/frontend/src/components/SecurityScanSection.tsx
@@ -27,7 +27,12 @@ import { useAuth } from '../context/AuthContext'
 // Types
 // ---------------------------------------------------------------------------
 
-export type ScanVerdict = 'APPROVE' | 'WARN' | 'BLOCK'
+// Verdicts:
+//   APPROVE — scan completed, no issues
+//   WARN    — scan completed, non-critical issues; needs explicit checkbox confirmation
+//   BLOCK   — scan completed, critical issues; needs admin override + reason ≥ 20 chars
+//   SKIPPED — admin chose to bypass the scan entirely; reason is optional. Audit logs the skip.
+export type ScanVerdict = 'APPROVE' | 'WARN' | 'BLOCK' | 'SKIPPED'
 
 interface ScanFinding {
   category: string
@@ -59,6 +64,8 @@ interface Props {
   onVerdict: (verdict: ScanVerdict | null, result: ScanResult | null) => void
   /** Called when admin overrides a BLOCK. */
   onOverride: (reason: string) => void
+  /** Called when admin types/clears the optional skip reason. */
+  onSkipReason?: (reason: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +128,7 @@ function verdictColors(v: ScanVerdict) {
 // Main component
 // ---------------------------------------------------------------------------
 
-export default function SecurityScanSection({ sourceUrl, authToken, onVerdict, onOverride }: Props) {
+export default function SecurityScanSection({ sourceUrl, authToken, onVerdict, onOverride, onSkipReason }: Props) {
   const { user } = useAuth()
   const isAdmin = user?.role === 'admin'
 
@@ -163,14 +170,21 @@ export default function SecurityScanSection({ sourceUrl, authToken, onVerdict, o
       })
   }, [sourceUrl, authToken, onVerdict])
 
-  // Handle skip checkbox
+  // Handle skip checkbox.
+  // Skipping the scan is an explicit admin decision — it passes the gate
+  // immediately. The audit log captures the skip (and optional reason)
+  // server-side, so we don't need a UI-side requirement to type something.
   function handleSkipToggle(checked: boolean) {
     setSkipScan(checked)
     if (checked) {
       setResult(null)
       setError(null)
-      onVerdict(null, null)
+      onVerdict('SKIPPED', null)
+      // Existing skipReason text (if any) flows up via the textarea onChange.
     } else {
+      // Clear any pending reason so the next install attempt doesn't carry stale text.
+      setSkipReason('')
+      onSkipReason?.('')
       // Re-run scan when unchecked
       hasRun.current = false
       setScanning(true)
@@ -379,9 +393,12 @@ export default function SecurityScanSection({ sourceUrl, authToken, onVerdict, o
                   <div className="space-y-1">
                     <textarea
                       value={skipReason}
-                      onChange={(e) => setSkipReason(e.target.value)}
+                      onChange={(e) => {
+                        setSkipReason(e.target.value)
+                        onSkipReason?.(e.target.value)
+                      }}
                       rows={1}
-                      placeholder="Reason for skipping (required)"
+                      placeholder="Motivo (opcional, será registrado no audit log)"
                       className="w-full bg-black/20 border border-[#344054] rounded px-2 py-1 text-[10px] text-[#D0D5DD] placeholder-[#667085] resize-none focus:outline-none focus:border-yellow-500/50"
                       onClick={(e) => e.stopPropagation()}
                     />

--- a/dashboard/frontend/src/components/UpdatePreviewModal.tsx
+++ b/dashboard/frontend/src/components/UpdatePreviewModal.tsx
@@ -202,7 +202,8 @@ export default function UpdatePreviewModal({
   // Wave 2.5 — canApply depends on scan verdict
   const scanGatePassed =
     scanVerdict === 'APPROVE' ||
-    scanVerdict === null /* skip */ ||
+    scanVerdict === 'SKIPPED' /* admin bypassed */ ||
+    scanVerdict === null /* legacy: still represents skip until a result arrives */ ||
     (scanVerdict === 'WARN' && confirmed) ||
     (scanVerdict === 'BLOCK' && !!overrideReason)
 


### PR DESCRIPTION
## Summary

Found by Davidson: the plugin install wizard's *Skip scan* checkbox didn't do anything useful. Marking it sent \`verdict=null\` upward, \`scanGatePassed\` evaluated to \`false\`, and *Confirmar instalação* stayed disabled / silently dropped the request. The skip-reason textarea was tagged *(required)* but had no minimum, no validation feedback, and was never sent to the backend.

## What changed

- Added \`'SKIPPED'\` to the \`ScanVerdict\` union and emit it from \`handleSkipToggle\` when the checkbox is checked.
- \`scanGatePassed\` now treats \`SKIPPED\` as a pass (same as \`APPROVE\`) — admin already made the call; backend audit-logs the skip regardless.
- Skip-reason textarea placeholder rewritten as **\"Motivo (opcional, será registrado no audit log)\"**. No length requirement. No client-side validation. The textarea exists for the audit trail, nothing else.
- New optional \`onSkipReason\` callback flows the textarea text up to the install body so the backend's existing \`skip_reason\` audit field gets populated.
- Install request now sends \`body.skip_scan = true\` + \`body.skip_reason\` when the verdict is \`SKIPPED\`. Backend (\`routes/plugins.py:670+\`) already accepts these — only the frontend was failing to emit them.
- \`UpdatePreviewModal\` updated to also accept \`'SKIPPED'\` (it relied on the legacy \`null === skip\` pattern; both paths now work).

## Why no required-reason

Davidson explicitly said justifying every skip is *bobagem*. The audit trail captures the action (admin id, timestamp, plugin slug, IP, optional reason). Refusing to act unless the admin types 20 characters of justification is friction that doesn't add security — it just teaches admins to type *\"ja ta ok\"*-equivalent boilerplate.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Manual: marking *Skip scan* allows *Confirmar instalação* to fire immediately without typing anything; with text, that text reaches the backend audit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow plugin installations and updates to explicitly bypass the security scan while still recording the action and optional reason for auditing.

Bug Fixes:
- Fix the Skip scan checkbox so that choosing to skip a scan no longer silently blocks plugin installation.

Enhancements:
- Introduce a dedicated SKIPPED scan verdict treated as a passing state in install and update flows, replacing the previous implicit null-based skip handling.
- Propagate an optional skip reason from the security scan UI into the plugin install request so it can be stored in backend audit logs.