### PR TITLE
fix(dashboard): close 4 user-reported bugs (#44, #60, #61, #62)

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -16,9 +16,9 @@ RUN npm run build
 # --- Stage 2: Python backend ---
 FROM python:3.12-slim AS runtime
 
-# System deps
+# System deps: curl for healthcheck + git for brain-repo restore/clone flow.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
+    curl git \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/Dockerfile.swarm.dashboard
+++ b/Dockerfile.swarm.dashboard
@@ -40,10 +40,11 @@ RUN npm install --omit=dev --no-audit --no-fund
 # ---- Stage 3: Python + Node runtime --------------------------------------
 FROM python:3.12-slim AS runtime
 
-# System deps: curl for healthcheck + Node.js 22 for terminal-server binary.
-# We use NodeSource so the final image is clean (no build toolchain).
+# System deps: curl for healthcheck + git for brain-repo restore/clone flow +
+# Node.js 22 for terminal-server binary. We use NodeSource so the final image
+# is clean (no build toolchain).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg openssl \
+        curl ca-certificates gnupg openssl git \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \

--- a/dashboard/backend/brain_repo/github_api.py
+++ b/dashboard/backend/brain_repo/github_api.py
@@ -101,12 +101,26 @@ def detect_brain_repos(token: str) -> list[dict]:
 
 
 def list_user_repos(token: str) -> list[dict]:
-    """List up to 100 private repos for the authenticated user."""
-    url = f"{_API_BASE}/user/repos?per_page=100&type=private"
-    status, body, _ = _get(url, token)
-    if status != 200 or not isinstance(body, list):
-        log.warning("list_user_repos: status %d", status)
-        return []
+    """List up to 300 repos for the authenticated user (owner + collaborator).
+
+    Paginates 3 pages of 100 (GitHub's max per_page). Returns both public and
+    private repos: a brain repo can legitimately be public (a .evo-brain file
+    is just a marker; the user may have intentionally created it in a public
+    repo to share state with collaborators). Filtering to private-only made
+    public brain repos invisible after a redeploy (#61).
+    """
+    results: list[dict] = []
+    for page in (1, 2, 3):
+        url = f"{_API_BASE}/user/repos?per_page=100&page={page}&affiliation=owner,collaborator"
+        status, body, _ = _get(url, token)
+        if status != 200 or not isinstance(body, list):
+            log.warning("list_user_repos: page %d status %d", page, status)
+            break
+        if not body:
+            break
+        results.extend(body)
+        if len(body) < 100:
+            break
     return [
         {
             "name": r.get("name", ""),
@@ -115,7 +129,7 @@ def list_user_repos(token: str) -> list[dict]:
             "private": r.get("private", False),
             "description": r.get("description", ""),
         }
-        for r in body
+        for r in results
     ]
 
 

--- a/dashboard/backend/knowledge/parser_install.py
+++ b/dashboard/backend/knowledge/parser_install.py
@@ -9,15 +9,51 @@ the user to install parser models (one-time, ~500MB Surya models).
 Sentinel file: ~/.cache/evonexus/marker_installed.ok
     Present → models cached; install endpoint returns "already_installed".
     Absent → download needed.
+
+Progress file: ~/.cache/evonexus/marker_install.progress.json
+    Written by the background download thread so the UI can poll
+    /api/knowledge/parsers/status while a long install is running.
+    The Surya model download regularly takes 10–30 minutes on a low-end
+    VPS, which exceeded the gunicorn worker timeout when the request was
+    handled synchronously — the worker was killed mid-download, the
+    socket reset, and the UI re-rendered the "Install" button as if the
+    install never happened (#44).
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 
+log = logging.getLogger(__name__)
+
 _SENTINEL = Path.home() / ".cache" / "evonexus" / "marker_installed.ok"
+_PROGRESS_FILE = Path.home() / ".cache" / "evonexus" / "marker_install.progress.json"
+_LOCK = threading.Lock()
+_THREAD: Optional[threading.Thread] = None
+
+
+def _read_progress() -> Optional[Dict[str, Any]]:
+    if not _PROGRESS_FILE.exists():
+        return None
+    try:
+        return json.loads(_PROGRESS_FILE.read_text())
+    except Exception:
+        return None
+
+
+def _write_progress(payload: Dict[str, Any]) -> None:
+    try:
+        _PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _PROGRESS_FILE.write_text(json.dumps(payload))
+    except Exception:
+        log.exception("failed to write marker install progress")
 
 
 def get_parser_status() -> Dict[str, Any]:
@@ -28,6 +64,11 @@ def get_parser_status() -> Dict[str, Any]:
             "marker_installed": bool,
             "models_cached": list[str],
             "cached_at": iso_timestamp | None,
+            "install_in_progress": bool,
+            "install_stage": str | None,
+            "install_progress": float | None,   # 0.0-1.0
+            "install_error": str | None,
+            "install_started_at": iso_timestamp | None,
         }
     """
     installed = _SENTINEL.exists()
@@ -43,28 +84,115 @@ def get_parser_status() -> Dict[str, Any]:
                 if d.is_dir() and ("surya" in d.name.lower() or "marker" in d.name.lower())
             ]
 
+    progress = _read_progress() or {}
+    in_progress = bool(progress.get("running")) and not installed
+
     return {
         "marker_installed": installed,
         "models_cached": models_cached,
         "cached_at": cached_at,
+        "install_in_progress": in_progress,
+        "install_stage": progress.get("stage"),
+        "install_progress": progress.get("progress"),
+        "install_error": progress.get("error"),
+        "install_started_at": progress.get("started_at"),
     }
+
+
+def _run_download() -> None:
+    """Background worker — downloads models and writes progress incrementally."""
+    from knowledge.parsers.marker_parser import (
+        download_marker_models as _download,
+        MarkerNotInstalledError,
+    )
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    _write_progress({
+        "running": True,
+        "stage": "starting",
+        "progress": 0.0,
+        "started_at": started_at,
+        "error": None,
+    })
+
+    def _cb(stage: str, progress: float) -> None:
+        _write_progress({
+            "running": True,
+            "stage": stage,
+            "progress": progress,
+            "started_at": started_at,
+            "error": None,
+        })
+
+    try:
+        _download(_cb)
+        _write_progress({
+            "running": False,
+            "stage": "done",
+            "progress": 1.0,
+            "started_at": started_at,
+            "error": None,
+        })
+    except MarkerNotInstalledError as exc:
+        log.error("marker install failed: %s", exc)
+        _write_progress({
+            "running": False,
+            "stage": "error",
+            "progress": 0.0,
+            "started_at": started_at,
+            "error": f"marker-pdf is not installed in the runtime: {exc}",
+        })
+    except Exception as exc:  # noqa: BLE001
+        log.exception("marker install crashed")
+        _write_progress({
+            "running": False,
+            "stage": "error",
+            "progress": 0.0,
+            "started_at": started_at,
+            "error": f"{type(exc).__name__}: {exc}",
+        })
+
+
+def start_marker_install() -> Dict[str, Any]:
+    """Start the Marker download in a background thread.
+
+    Returns immediately with the current status. The caller polls
+    GET /api/knowledge/parsers/status to follow progress.
+
+    Idempotent: if already installed, returns ``already_installed``.
+    If a download is already running, returns the current progress
+    without starting a second thread.
+    """
+    global _THREAD
+
+    if _SENTINEL.exists():
+        return {
+            "status": "already_installed",
+            "cached_at": _SENTINEL.read_text().strip(),
+        }
+
+    with _LOCK:
+        if _THREAD is not None and _THREAD.is_alive():
+            return {"status": "in_progress", **(_read_progress() or {})}
+
+        _THREAD = threading.Thread(
+            target=_run_download,
+            name="marker-install",
+            daemon=True,
+        )
+        _THREAD.start()
+        # Give the thread a beat to write its first progress entry.
+        time.sleep(0.1)
+        return {"status": "started", **(_read_progress() or {})}
 
 
 def download_marker_models(
     progress_callback: Optional[Callable[[str, float], None]] = None
 ) -> Dict[str, Any]:
-    """Download and cache Marker/Surya models.
+    """Synchronous download — kept for tests and CLI use only.
 
-    Delegates to ``marker_parser.download_marker_models``.
-
-    Args:
-        progress_callback: optional callable(stage: str, progress: float 0.0-1.0)
-
-    Returns:
-        {"status": "ok" | "already_installed", "cached_at": iso_timestamp}
-
-    Raises:
-        MarkerNotInstalledError: if marker-pdf is not installed.
+    The HTTP route should call ``start_marker_install`` instead, since the
+    download easily exceeds the gunicorn worker timeout.
     """
     from knowledge.parsers.marker_parser import download_marker_models as _download
     return _download(progress_callback)

--- a/dashboard/backend/routes/backups.py
+++ b/dashboard/backend/routes/backups.py
@@ -97,7 +97,7 @@ def create_backup():
     if denied:
         return denied
 
-    if _running_jobs.get("backup"):
+    if _running_jobs.get("backup", {}).get("status") == "running":
         return jsonify({"error": "A backup is already running"}), 409
 
     target = request.get_json(silent=True) or {}
@@ -149,6 +149,9 @@ def restore_backup(filename):
     mode = data.get("mode", "merge")
     if mode not in ("merge", "replace"):
         return jsonify({"error": "Invalid mode. Use 'merge' or 'replace'"}), 400
+
+    if _running_jobs.get("restore", {}).get("status") == "running":
+        return jsonify({"error": "A restore is already running"}), 409
 
     def _run():
         try:

--- a/dashboard/backend/routes/knowledge.py
+++ b/dashboard/backend/routes/knowledge.py
@@ -405,21 +405,34 @@ def parser_status():
 def parser_install():
     """Trigger Marker model download (ADR-002).
 
-    Downloads Surya models (~500 MB) to ~/.cache/huggingface/.
-    Creates sentinel ~/.cache/evonexus/marker_installed.ok on completion.
-    Idempotent — returns "already_installed" if sentinel exists.
+    Spawns a background thread that downloads Surya models
+    (~500 MB) to ~/.cache/huggingface/ and creates the sentinel
+    ~/.cache/evonexus/marker_installed.ok on completion.
+
+    Returns immediately with 202 Accepted — the UI polls
+    GET /api/knowledge/parsers/status to track progress. Doing the
+    download in-process synchronously regularly exceeded the gunicorn
+    worker timeout on small VPS, which killed the worker mid-download
+    and made the UI re-render the "Install" button as if nothing had
+    happened (#44).
+
+    Idempotent — returns ``already_installed`` if the sentinel exists,
+    or ``in_progress`` if another install is already running.
     """
     _assert_key()
-    from knowledge.parser_install import download_marker_models
-    from knowledge.parsers.marker_parser import MarkerNotInstalledError
+    from knowledge.parser_install import start_marker_install
 
     try:
-        result = download_marker_models()
-        return jsonify(result)
-    except MarkerNotInstalledError as exc:
-        return jsonify({"error": str(exc)}), 422
-    except Exception as exc:
+        result = start_marker_install()
+    except Exception as exc:  # noqa: BLE001
         return jsonify({"error": str(exc)}), 500
+
+    status = result.get("status")
+    if status == "already_installed":
+        return jsonify(result), 200
+    if status == "in_progress":
+        return jsonify(result), 200
+    return jsonify(result), 202
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bundle of 4 small, independent fixes for issues reported by users this week. Each is a minimal change with no behavioural risk; grouped here to keep ops review to one PR.

### #62 — Brain restore via git failed silently
`Dockerfile.swarm.dashboard` (the one that builds the published `evoapicloud/evo-nexus-dashboard:latest`) was missing **git** in its apt-get layer. Any path that shells out to git inside the container — brain repo restore, snapshot clone — raised `git: not found`. Also added git to `Dockerfile.dashboard` for parity.

### #61 — Existing brain repo not found after redeploy
`detect_brain_repos()` relied on `list_user_repos()` which hit `/user/repos?type=private`. A `.evo-brain` marker is just a marker; the repo can legitimately be public. Switched to `affiliation=owner,collaborator` with 3-page pagination and dropped the visibility filter. The existing `.evo-brain` content check downstream still gates which repos are returned.

### #60 — POST /api/backups returned 409 forever after first backup
Reported with full root-cause analysis by @abipci (PDF in the issue). The guard read `if _running_jobs.get("backup")` which is truthy for any non-empty dict — including the `{"status": "done"}` terminal state. After the first backup, every subsequent POST got 409 until the dashboard restarted. Also added the same status-running guard to `/restore`, which had no concurrency check at all (two simultaneous restores could corrupt the DB).

### #44 — Marker model install button reappears mid-download
`POST /api/knowledge/parsers/install` ran `download_marker_models()` synchronously inside the Flask request. The Surya model download takes 10–30 minutes on a small VPS, well past the gunicorn worker timeout. The worker was killed mid-run, the socket reset, and the UI re-rendered the "Install" button as if the install had never started. Moved the work into a daemon thread that writes progress to `~/.cache/evonexus/marker_install.progress.json`; the existing `GET /parsers/status` endpoint now exposes `install_in_progress`, `install_stage`, `install_progress` and `install_error` so the UI can poll. Endpoint returns 202 Accepted on start and 200 for already_installed / in_progress.

## Test plan
- [x] `uv run pytest dashboard/tests` passa (42/42)
- [x] `uv run python -c "from routes import backups, knowledge"` — imports OK
- [x] `uv run python -c "from brain_repo.github_api import list_user_repos"` — imports OK
- [ ] Build da imagem e `docker exec evonexus-dashboard which git` retorna `/usr/bin/git` (validar no CI/staging)
- [ ] POST `/api/backups` duas vezes seguidas: segunda chamada deve aceitar (era o que falhava em #60)
- [ ] POST `/api/knowledge/parsers/install` retorna 202 imediatamente; GET `/api/knowledge/parsers/status` mostra `install_in_progress: true` e `install_stage` evoluindo
- [ ] Repo público com `.evo-brain` aparece em `GET /api/brain-repo/detect` (#61)

Closes #44
Closes #60
Closes #61
Closes #62