### PR TITLE
feat(skills): add int-uptime-kuma skill (Uptime Kuma monitoring)

### DIFF
--- a/.claude/skills/int-uptime-kuma/SKILL.md
+++ b/.claude/skills/int-uptime-kuma/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: int-uptime-kuma
+description: "Monitor and manage Uptime Kuma monitors. List status of all services, create HTTP/keyword monitors with custom headers, pause, resume and delete monitors. Reading uses Prometheus metrics (fast, no session needed). Writing uses Socket.io with username/password auth. Configure your instance via the UPTIME_KUMA_* env vars."
+metadata:
+  openclaw:
+    requires:
+      env:
+        - UPTIME_KUMA_URL
+        - UPTIME_KUMA_API_KEY
+        - UPTIME_KUMA_USERNAME
+        - UPTIME_KUMA_PASSWORD
+      bins:
+        - python3
+    primaryEnv: UPTIME_KUMA_API_KEY
+    files:
+      - "scripts/*"
+---
+
+# Uptime Kuma — Monitoramento
+
+Configure a instância via env (`UPTIME_KUMA_URL`). Compatível com Uptime Kuma **2.x** (`louislam/uptime-kuma`, validado na 2.2.1).
+
+**Arquitetura de acesso:**
+- Leitura (status, listagem): `/metrics` Prometheus com Basic Auth via API key (rápido, stateless, stdlib só)
+- Escrita (criar, editar, pausar, retomar, deletar): Socket.io sobre WebSocket via `python-socketio` (sessão única persistente, login real verificado)
+
+> **Interpretador:** os comandos de **escrita** dependem de `python-socketio` (já em `pyproject.toml`). Rode-os com o Python do projeto: `.venv/bin/python` (ou `uv run python`). A **leitura** (`status`/`get`) usa só a stdlib e roda com qualquer `python3`. O `smoke` roda com `python3`, mas seu step `write_auth` (login do caminho de escrita) só executa de fato com `.venv/bin/python` — com `python3` ele reporta `SKIP`. Para um smoke completo, use `.venv/bin/python`.
+
+> **Compat Uptime Kuma 2.x:** no schema v2 o campo `conditions` é NOT NULL e `accepted_statuscodes` precisa ser lista — o cliente já injeta ambos (validado ao vivo na 2.2.1). A lib oficial `uptime-kuma-api` (lucasheld) só vai até 1.23.2, por isso a implementação é própria.
+
+## Mutation-safety (escrita)
+
+Todo comando de escrita (`add`/`edit`/`pause`/`resume`/`delete`) é **dry-run por padrão**:
+sem `--execute` o comando **não muta** — imprime o que faria (ação + payload/alvo) em JSON
+e sai 0, **sem abrir socket de escrita**. Mesma semântica do `int-blue`.
+
+- **`--execute`** efetiva a mutação. Mantém o ack-check (erro do servidor → exit 1).
+- **`--source`** (obrigatório em todo write): `human` | `agent:<slug>` | `routine:<name>`.
+  Registrado no evento estruturado (stderr) para audit trail.
+- **`snapshot_before`** em `edit` e `delete`: o estado atual do monitor (via Prometheus) é
+  capturado e emitido no output para rollback manual. Em `delete`, o snapshot também é o
+  2º fator (ver abaixo).
+- **`--max-writes`** (global, default 5): teto de writes por execução.
+
+### Gates por blast-radius
+
+| Comando | Blast radius | Gate |
+|---|---|---|
+| `add` / `edit` / `resume` | baixo | dry-run default + `--execute` |
+| `pause` | cega o monitoramento de um alvo de produção | dry-run default + `--execute` (warning no output) |
+| `delete` | destrutivo, **irreversível** | dry-run default + `--execute` **+** `--confirm "<nome exato do monitor>"` (2º fator: o nome tem que bater com o snapshot real; sem snapshot disponível, o delete é bloqueado) |
+
+## Setup (uma vez)
+
+Variáveis no `.env` (a escrita autentica com `USERNAME`/`PASSWORD`; login é verificado e aborta em falha):
+```
+UPTIME_KUMA_URL=https://uptime.example.com
+UPTIME_KUMA_API_KEY=uk1_...
+UPTIME_KUMA_USERNAME=admin
+UPTIME_KUMA_PASSWORD=...
+```
+
+## Comandos
+
+### Ver status de todos os monitores
+```bash
+python3 .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py status
+```
+
+### Filtrar por nome
+```bash
+python3 .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py status --name "Evolution"
+```
+
+### Ver apenas monitores com DOWN
+```bash
+python3 .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py status --down
+```
+
+### Ver detalhes de um monitor
+```bash
+python3 .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py get <id>
+```
+
+> **Lembrete:** sem `--execute` qualquer comando abaixo é dry-run (não muta). Veja o que
+> faria primeiro; só então repita com `--execute`. `--source` é sempre obrigatório.
+
+### Criar monitor HTTP simples (escrita → use `.venv/bin/python`)
+```bash
+# dry-run (default — só imprime o que faria):
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py add \
+  "Nome do monitor" "https://example.com/health" \
+  --interval 60 --maxretries 3 --source agent:atlas-project
+# efetivar:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py add \
+  "Nome do monitor" "https://example.com/health" \
+  --interval 60 --maxretries 3 --source agent:atlas-project --execute
+```
+
+### Criar monitor para Evolution Go (com header apikey) — escrita → use `.venv/bin/python`
+```bash
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py add \
+  "Evolution Go — WhatsApp" "https://your-evolution-go.example.com/instance/status" \
+  --type keyword \
+  --headers '{"apikey":"<apikey>"}' \
+  --keyword '"Connected":true' \
+  --interval 60 --source agent:atlas-project --execute
+```
+
+### Criar monitor para Evolution API (com header apikey) — escrita → use `.venv/bin/python`
+```bash
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py add \
+  "WhatsApp — minha-instancia" \
+  "https://your-evolution-api.example.com/instance/connectionState/minha-instancia" \
+  --type keyword \
+  --headers '{"apikey":"<global_apikey>"}' \
+  --keyword '"state":"open"' \
+  --interval 60 --source agent:atlas-project --execute
+```
+
+### Editar monitor (escrita → use `.venv/bin/python`)
+```bash
+# dry-run mostra snapshot_before + o payload que enviaria:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py edit <id> \
+  "Novo nome" "https://example.com/health" --interval 120 --source agent:atlas-project
+# efetivar:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py edit <id> \
+  "Novo nome" "https://example.com/health" --interval 120 --source agent:atlas-project --execute
+```
+
+### Pausar monitor (escrita → use `.venv/bin/python`)
+```bash
+# pause CEGA o monitoramento do alvo — confira o dry-run antes:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py pause <id> \
+  --source agent:atlas-project --execute
+```
+
+### Retomar monitor (escrita → use `.venv/bin/python`)
+```bash
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py resume <id> \
+  --source agent:atlas-project --execute
+```
+
+### Deletar monitor (escrita → use `.venv/bin/python`) — IRREVERSÍVEL, exige 2º fator
+```bash
+# 1) dry-run mostra o snapshot_before e o nome exato a confirmar:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py delete <id> \
+  --source agent:atlas-project
+# 2) efetivar — --confirm tem que bater com o nome real do monitor:
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py delete <id> \
+  --source agent:atlas-project --execute --confirm "Nome exato do monitor"
+```
+
+### Smoke test (saúde da skill — exit 0 sempre, JSON)
+```bash
+# leitura + escrita: use .venv/bin/python para exercitar o step write_auth
+.venv/bin/python .claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py smoke
+```
+Reporta `{overall, steps[], duration_ms}`. Steps: `auth` (env de leitura), `fetch_metrics`
+(Prometheus) e `write_auth` (login real do caminho de escrita, **sem mutar nada**). Se rodado
+com `python3` (sem `python-socketio`) o `write_auth` reporta `SKIP` — daí a recomendação de
+`.venv/bin/python` para um smoke completo.
+
+## Output
+
+JSON para stdout. Campos de status:
+- `status`: `UP` | `DOWN` | `PENDING` | `MAINTENANCE`
+- `uptime_24h`: porcentagem de uptime nas últimas 24h
+- `response_ms`: tempo de resposta em ms
+- `cert_days`: dias restantes no certificado SSL
+- `cert_valid`: certificado válido?
+
+## Notas
+
+- O campo `monitor_url` nos labels Prometheus é a URL configurada no monitor.
+- Monitores do tipo `group` aparecem no status mas não têm URL própria.
+- Para Evolution Go, usar `--type keyword` com `--headers` e `--keyword '"Connected":true'` — a URL não tem o nome da instância (é identificada pelo header `apikey`).
+- Para Evolution API, a URL inclui o nome da instância: `/instance/connectionState/{name}`.
+
+## Fronteiras de responsabilidade
+
+- **Esta skill** cobre **monitoramento de disponibilidade** (uptime/health checks): ler status,
+  criar/editar/pausar/retomar/deletar monitores no Uptime Kuma.
+- **Containers, stacks e Docker** (saber se um serviço *está rodando* / reiniciar) são do
+  **`int-portainer`** — esta skill só observa o endpoint externo, não toca a infra.
+- **Orquestração de agentes** (decisão de *agir* sobre um serviço caído, alertas, runbooks)
+  é dos **heartbeats** (`config/heartbeats.yaml`) — esta skill é a sonda; quem decide e age é o heartbeat.

--- a/.claude/skills/int-uptime-kuma/SKILL.md
+++ b/.claude/skills/int-uptime-kuma/SKILL.md
@@ -60,6 +60,15 @@ UPTIME_KUMA_USERNAME=admin
 UPTIME_KUMA_PASSWORD=...
 ```
 
+> **Login falha alto e acionável.** O caminho de escrita **nunca** segue com sessão
+> não-autenticada (era o bug que devolvia `{}` em silêncio). Se o servidor rejeita o
+> login, o erro distingue as duas causas e some o palpite:
+> - `authIncorrectCreds` → usuário/senha **stale ou incorretos** (o usuário não é
+>   necessariamente `admin` — confira o `.env` contra a instância).
+> - mensagem de `token`/`2FA` → a conta tem **2FA ativo**; o login Socket.io exige TOTP.
+>   Use uma conta de serviço sem 2FA para a automação.
+> A resposta crua do servidor sempre vem anexada à mensagem.
+
 ## Comandos
 
 ### Ver status de todos os monitores

--- a/.claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py
+++ b/.claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""
+Uptime Kuma client — leitura via Prometheus /metrics, gestão via Socket.io.
+
+Leitura (status, listagem, get): /metrics Prometheus com Basic Auth (API key,
+stateless — rápido e robusto).
+Escrita (add, edit, pause, resume, delete): Socket.io sobre WebSocket via
+python-socketio, com sessão única persistente e login real (verifica `ok`).
+
+Mutation-safety: writes são dry-run por padrão (não abrem socket). Use --execute
+para efetivar. --source (human | agent:<slug> | routine:<name>) é obrigatório em
+todo write. edit/delete capturam snapshot_before (estado atual via Prometheus)
+para rollback manual. delete exige um 2º fator (--confirm <nome do monitor>).
+
+Compatível com Uptime Kuma 2.x (campo `conditions` é NOT NULL no schema v2;
+`accepted_statuscodes` precisa ser lista). Instância via env (sem hardcode).
+"""
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+_write_count = 0
+_max_writes = 5
+
+
+# ── env ──────────────────────────────────────────────────────────────────────
+
+def _load_dotenv():
+    env_path = Path(__file__).resolve().parents[4] / ".env"
+    if not env_path.exists():
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            if k.strip() and k.strip() not in os.environ:
+                os.environ[k.strip()] = v.strip()
+
+_load_dotenv()
+
+BASE_URL   = os.environ.get("UPTIME_KUMA_URL", "").rstrip("/")
+API_KEY    = os.environ.get("UPTIME_KUMA_API_KEY", "")
+USERNAME   = os.environ.get("UPTIME_KUMA_USERNAME", "")
+PASSWORD   = os.environ.get("UPTIME_KUMA_PASSWORD", "")
+UA         = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+
+# ── Prometheus metrics reader ────────────────────────────────────────────────
+
+def _fetch_metrics() -> str:
+    cred = base64.b64encode(f"apikey:{API_KEY}".encode()).decode()
+    req = urllib.request.Request(
+        f"{BASE_URL}/metrics",
+        headers={"Authorization": f"Basic {cred}", "User-Agent": UA}
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return r.read().decode()
+
+
+def _parse_metrics(raw: str) -> list[dict]:
+    """Parse Prometheus metrics into a list of monitor dicts."""
+    monitors: dict[str, dict] = {}
+    for line in raw.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        # e.g.: monitor_status{monitor_id="3",monitor_name="...",monitor_type="http",...} 1
+        metric_name = line.split("{")[0]
+        if metric_name not in (
+            "monitor_status", "monitor_uptime_ratio",
+            "monitor_response_time", "monitor_cert_days_remaining",
+            "monitor_cert_is_valid",
+        ):
+            continue
+        try:
+            labels_str = line[line.index("{") + 1:line.index("}")]
+            value_str  = line[line.index("}") + 1:].strip()
+            # only use the base value (no 'window' label for uptime)
+            labels: dict[str, str] = {}
+            for part in labels_str.split(","):
+                k, _, v = part.partition("=")
+                labels[k.strip()] = v.strip().strip('"')
+            if "window" in labels:
+                continue  # skip windowed uptime duplicates; keep only non-windowed
+            mid = labels.get("monitor_id", "")
+            if not mid:
+                continue
+            if mid not in monitors:
+                monitors[mid] = {
+                    "id": mid,
+                    "name":  labels.get("monitor_name", ""),
+                    "type":  labels.get("monitor_type", ""),
+                    "url":   labels.get("monitor_url", ""),
+                }
+            try:
+                val = float(value_str)
+            except ValueError:
+                continue
+            if metric_name == "monitor_status":
+                STATUS_MAP = {1: "UP", 0: "DOWN", 2: "PENDING", 3: "MAINTENANCE"}
+                monitors[mid]["status"] = STATUS_MAP.get(int(val), str(int(val)))
+            elif metric_name == "monitor_uptime_ratio":
+                monitors[mid]["uptime_24h"] = f"{val * 100:.1f}%"
+            elif metric_name == "monitor_response_time":
+                monitors[mid]["response_ms"] = int(val)
+            elif metric_name == "monitor_cert_days_remaining":
+                monitors[mid]["cert_days"] = int(val)
+            elif metric_name == "monitor_cert_is_valid":
+                monitors[mid]["cert_valid"] = bool(int(val))
+        except (ValueError, IndexError):
+            continue
+    return sorted(monitors.values(), key=lambda m: int(m["id"]))
+
+
+# ── Socket.io client (WebSocket via python-socketio) ──────────────────────────
+
+class UKSocket:
+    """Socket.io client over WebSocket using python-socketio.
+
+    A single persistent connection avoids the session-loss problem of a
+    curl-per-request long-polling model. Login is verified (`ok` must be True);
+    a failed login raises so callers never operate on an unauthenticated socket.
+    """
+
+    def __init__(self):
+        self._sio = None
+
+    def connect(self, attempts: int = 3):
+        # Wall-clock ceiling matters: this client feeds autonomous monitoring
+        # (heartbeats) — it must fail fast, not hang. Worst case ~3 attempts ×
+        # 8s wait_timeout + linear backoff (2+4s) ≈ 30s, then it gives up.
+        import socketio
+        last_err: Optional[Exception] = None
+        for i in range(attempts):
+            sio = socketio.Client(reconnection=False, request_timeout=10)
+            try:
+                sio.connect(BASE_URL, transports=["websocket"], wait_timeout=8)
+                self._sio = sio
+                # let the server emit info / loginRequired before we proceed
+                time.sleep(0.4)
+                return
+            except Exception as e:  # noqa: BLE001 — retry any connect failure
+                last_err = e
+                try:
+                    sio.disconnect()
+                except Exception:
+                    pass
+                time.sleep(2.0 * (i + 1))
+        raise RuntimeError(f"socket connect failed after {attempts} attempts: {last_err}")
+
+    def login(self) -> dict:
+        """Authenticate. Raises if the server rejects the credentials.
+
+        The returned token is not stored: python-socketio keeps the underlying
+        connection authenticated for the lifetime of this socket, so every
+        subsequent `call()` runs on the logged-in session without re-sending it.
+        """
+        resp = self._sio.call(
+            "login", {"username": USERNAME, "password": PASSWORD, "token": ""},
+            timeout=15,
+        )
+        if not (isinstance(resp, dict) and resp.get("ok")):
+            raise RuntimeError(f"login failed: {json.dumps(resp)}")
+        return resp
+
+    def call(self, event: str, *args) -> Any:
+        return self._sio.call(event, *args, timeout=20)
+
+    def close(self):
+        if self._sio is not None:
+            try:
+                self._sio.disconnect()
+            except Exception:
+                pass
+
+
+def _socket_session() -> UKSocket:
+    if not USERNAME or not PASSWORD:
+        print(json.dumps({"error": "UPTIME_KUMA_USERNAME / UPTIME_KUMA_PASSWORD not set"}))
+        sys.exit(1)
+    sio = UKSocket()
+    try:
+        sio.connect()
+        sio.login()
+    except Exception as e:  # noqa: BLE001 — surface the real failure, never swallow
+        sio.close()
+        print(json.dumps({"error": str(e)[:500]}))
+        sys.exit(1)
+    return sio
+
+
+def _check_ack(resp: Any) -> Any:
+    """A write ack must be {ok: true}. Otherwise emit the error + exit non-zero.
+
+    Fixes the prior silent-failure bug where a server error (e.g. auth or schema)
+    returned `{}` / `{ok:false}` but the CLI still exited 0.
+    """
+    if isinstance(resp, dict) and resp.get("ok"):
+        return resp
+    print(json.dumps({"error": "operation failed", "detail": resp}, ensure_ascii=False))
+    sys.exit(1)
+
+
+# ── mutation-safety (dry-run default, --source, --max-writes, logging) ─────────
+
+_SOURCE_PATTERN = re.compile(r"^(human|agent:[a-z0-9_-]+|routine:[a-z0-9_-]+)$")
+
+
+def validate_source(source: Optional[str]) -> str:
+    """A escrita exige atribuição de origem (mesma semântica do int-blue)."""
+    if not source or not _SOURCE_PATTERN.match(source):
+        print(json.dumps({
+            "error": ("--source obrigatório. Valores aceitos: "
+                      "human | agent:<slug> | routine:<name>. "
+                      f"Recebido: {source!r}")
+        }, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    return source
+
+
+def check_write_limit() -> None:
+    """Teto de writes por execução — defesa contra loop de mutação acidental."""
+    global _write_count, _max_writes
+    if _write_count >= _max_writes:
+        print(json.dumps({
+            "error": f"Limite de {_max_writes} writes por execução atingido. "
+                     "Use --max-writes para aumentar."
+        }), file=sys.stderr)
+        sys.exit(1)
+    _write_count += 1
+
+
+def log_event(op: str, status: str, duration_ms: float, extra: Optional[dict] = None) -> None:
+    """Evento estruturado em stderr (audit trail; stdout fica para o resultado)."""
+    entry = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "op": op,
+        "status": status,
+        "duration_ms": round(duration_ms),
+    }
+    if extra:
+        entry.update(extra)
+    print(json.dumps(entry, ensure_ascii=False), file=sys.stderr)
+
+
+def _snapshot_monitor(monitor_id: Any) -> Optional[dict]:
+    """Captura o estado atual de um monitor via Prometheus (read-only).
+
+    Usado antes de edit/delete para registrar `snapshot_before` (rollback manual).
+    Graceful: se a leitura falhar ou o monitor não aparecer nos metrics (ex.:
+    pausado não emite `monitor_status`), retorna None — nunca aborta a operação.
+    """
+    try:
+        monitors = _parse_metrics(_fetch_metrics())
+    except Exception:  # noqa: BLE001 — snapshot é best-effort, não bloqueia o write
+        return None
+    for m in monitors:
+        if str(m.get("id")) == str(monitor_id):
+            return m
+    return None
+
+
+def _build_monitor(args, with_id: bool = False) -> dict:
+    """Build a monitor payload with the fields Uptime Kuma 2.x requires.
+
+    `conditions` is NOT NULL in the v2 schema; `accepted_statuscodes` must be a
+    list (the server iterates it). Defaults mirror the Uptime Kuma UI.
+    """
+    monitor = {
+        "type":               args.type,
+        "name":               args.name,
+        "url":                args.url,
+        "interval":           args.interval,
+        "retryInterval":      args.retry_interval,
+        "resendInterval":     0,
+        "maxretries":         args.maxretries,
+        "active":             True,
+        "notificationIDList": {},
+        "accepted_statuscodes": [str(args.expected_status)]
+                                if args.expected_status is not None
+                                else ["200-299"],
+        "method":             "GET",
+        "maxredirects":       10,
+        "timeout":            48,
+        "ignoreTls":          False,
+        "upsideDown":         False,
+        "expiryNotification": False,
+        "conditions":         [],
+    }
+    if with_id:
+        monitor["id"] = int(args.id)
+    if args.headers:
+        try:
+            monitor["headers"] = json.loads(args.headers)
+        except json.JSONDecodeError:
+            print(json.dumps({"error": "invalid --headers JSON"}))
+            sys.exit(1)
+    if args.keyword:
+        monitor["keyword"] = args.keyword
+    return monitor
+
+
+# ── commands ─────────────────────────────────────────────────────────────────
+
+def _smoke_write_auth() -> dict:
+    """Exercise the WRITE path login (connect + login, NO mutation).
+
+    Returns a step dict. Graceful: never raises — reports SKIP if creds /
+    python-socketio are unavailable, FAIL if the auth itself is rejected. This
+    catches auth regressions the read-only Prometheus step is blind to (the bug
+    that motivated Fase 1).
+    """
+    ts = time.monotonic()
+    if not USERNAME or not PASSWORD:
+        return {"step": "write_auth", "status": "SKIP",
+                "reason": "UPTIME_KUMA_USERNAME / UPTIME_KUMA_PASSWORD not set",
+                "duration_ms": round((time.monotonic() - ts) * 1000)}
+    try:
+        import socketio  # noqa: F401 — presence check; UKSocket.connect imports it
+    except Exception:
+        return {"step": "write_auth", "status": "SKIP",
+                "reason": "python-socketio not installed (run write path with .venv/bin/python)",
+                "duration_ms": round((time.monotonic() - ts) * 1000)}
+    sio = UKSocket()
+    try:
+        sio.connect()
+        sio.login()  # raises on rejected credentials
+        return {"step": "write_auth", "status": "PASS",
+                "duration_ms": round((time.monotonic() - ts) * 1000)}
+    except Exception as e:  # noqa: BLE001 — never crash the smoke
+        return {"step": "write_auth", "status": "FAIL",
+                "error": str(e)[:300],
+                "duration_ms": round((time.monotonic() - ts) * 1000)}
+    finally:
+        sio.close()
+
+
+def cmd_smoke(_args=None):
+    """Smoke test: read auth + fetch metrics + write-path login. Always exits 0 with JSON."""
+    overall = "PASS"
+    steps = []
+    t0 = time.monotonic()
+
+    # step 1: auth — check required env vars
+    ts = time.monotonic()
+    if not BASE_URL or not API_KEY:
+        missing = []
+        if not BASE_URL:
+            missing.append("UPTIME_KUMA_URL")
+        if not API_KEY:
+            missing.append("UPTIME_KUMA_API_KEY")
+        steps.append({"step": "auth", "status": "FAIL",
+                       "error": f"Missing: {', '.join(missing)}",
+                       "duration_ms": round((time.monotonic() - ts) * 1000)})
+        overall = "FAIL"
+        print(json.dumps({"overall": overall, "steps": steps,
+                           "duration_ms": round((time.monotonic() - t0) * 1000)}))
+        sys.exit(0)
+    steps.append({"step": "auth", "status": "PASS",
+                   "duration_ms": round((time.monotonic() - ts) * 1000)})
+
+    # step 2: fetch metrics (reuses _fetch_metrics — same as cmd_status)
+    ts = time.monotonic()
+    try:
+        raw = _fetch_metrics()
+        monitors = _parse_metrics(raw)
+        down = sum(1 for m in monitors if m.get("status") == "DOWN")
+        steps.append({"step": "fetch_metrics", "status": "PASS",
+                       "monitor_count": len(monitors), "down": down,
+                       "duration_ms": round((time.monotonic() - ts) * 1000)})
+    except Exception as e:
+        steps.append({"step": "fetch_metrics", "status": "FAIL",
+                       "error": str(e)[:300],
+                       "duration_ms": round((time.monotonic() - ts) * 1000)})
+        overall = "FAIL"
+
+    # step 3: write-path login (no mutation) — SKIP doesn't fail overall, FAIL does
+    wa = _smoke_write_auth()
+    steps.append(wa)
+    if wa["status"] == "FAIL":
+        overall = "FAIL"
+
+    print(json.dumps({"overall": overall, "steps": steps,
+                       "duration_ms": round((time.monotonic() - t0) * 1000)}))
+    sys.exit(0)
+
+
+def cmd_status(args):
+    raw = _fetch_metrics()
+    monitors = _parse_metrics(raw)
+    if args.name:
+        monitors = [m for m in monitors if args.name.lower() in m["name"].lower()]
+    if args.down:
+        monitors = [m for m in monitors if m.get("status") == "DOWN"]
+    print(json.dumps(monitors, indent=2, ensure_ascii=False))
+
+
+def cmd_get(args):
+    raw = _fetch_metrics()
+    monitors = _parse_metrics(raw)
+    match = [m for m in monitors if str(m["id"]) == str(args.id)]
+    if not match:
+        print(json.dumps({"error": f"monitor {args.id} not found"}))
+        sys.exit(1)
+    print(json.dumps(match[0], indent=2, ensure_ascii=False))
+
+
+def cmd_add(args):
+    validate_source(args.source)
+    monitor = _build_monitor(args)
+    if not args.execute:
+        log_event("add", "dry_run", 0, {"source": args.source})
+        print(json.dumps({"dry_run": True, "would": "add", "monitor": monitor},
+                         indent=2, ensure_ascii=False))
+        return
+    check_write_limit()
+    t0 = time.monotonic()
+    sio = _socket_session()
+    try:
+        resp = _check_ack(sio.call("add", monitor))
+        log_event("add", "ok", (time.monotonic() - t0) * 1000,
+                  {"source": args.source, "monitorID": resp.get("monitorID")})
+        print(json.dumps({**resp, "dry_run": False}, indent=2, ensure_ascii=False))
+    finally:
+        sio.close()
+
+
+def cmd_edit(args):
+    validate_source(args.source)
+    monitor = _build_monitor(args, with_id=True)
+    snapshot = _snapshot_monitor(args.id)
+    if not args.execute:
+        log_event("edit", "dry_run", 0, {"source": args.source, "id": int(args.id)})
+        print(json.dumps({"dry_run": True, "would": "edit",
+                          "snapshot_before": snapshot, "monitor": monitor},
+                         indent=2, ensure_ascii=False))
+        return
+    check_write_limit()
+    t0 = time.monotonic()
+    sio = _socket_session()
+    try:
+        resp = _check_ack(sio.call("editMonitor", monitor))
+        log_event("edit", "ok", (time.monotonic() - t0) * 1000,
+                  {"source": args.source, "id": int(args.id)})
+        print(json.dumps({**resp, "snapshot_before": snapshot, "dry_run": False},
+                         indent=2, ensure_ascii=False))
+    finally:
+        sio.close()
+
+
+def cmd_pause(args):
+    validate_source(args.source)
+    # pause cega o monitoramento de um alvo de produção — gate: exige --execute.
+    if not args.execute:
+        log_event("pause", "dry_run", 0, {"source": args.source, "id": int(args.id)})
+        print(json.dumps({"dry_run": True, "would": "pause", "id": int(args.id),
+                          "warning": "pausar cega o monitoramento deste alvo"},
+                         indent=2, ensure_ascii=False))
+        return
+    check_write_limit()
+    t0 = time.monotonic()
+    sio = _socket_session()
+    try:
+        resp = _check_ack(sio.call("pauseMonitor", int(args.id)))
+        log_event("pause", "ok", (time.monotonic() - t0) * 1000,
+                  {"source": args.source, "id": int(args.id)})
+        print(json.dumps({**resp, "dry_run": False}, indent=2, ensure_ascii=False))
+    finally:
+        sio.close()
+
+
+def cmd_resume(args):
+    validate_source(args.source)
+    if not args.execute:
+        log_event("resume", "dry_run", 0, {"source": args.source, "id": int(args.id)})
+        print(json.dumps({"dry_run": True, "would": "resume", "id": int(args.id)},
+                         indent=2, ensure_ascii=False))
+        return
+    check_write_limit()
+    t0 = time.monotonic()
+    sio = _socket_session()
+    try:
+        resp = _check_ack(sio.call("resumeMonitor", int(args.id)))
+        log_event("resume", "ok", (time.monotonic() - t0) * 1000,
+                  {"source": args.source, "id": int(args.id)})
+        print(json.dumps({**resp, "dry_run": False}, indent=2, ensure_ascii=False))
+    finally:
+        sio.close()
+
+
+def cmd_delete(args):
+    validate_source(args.source)
+    snapshot = _snapshot_monitor(args.id)
+    if not args.execute:
+        log_event("delete", "dry_run", 0, {"source": args.source, "id": int(args.id)})
+        print(json.dumps({"dry_run": True, "would": "delete", "id": int(args.id),
+                          "snapshot_before": snapshot,
+                          "warning": "delete é IRREVERSÍVEL — confirme com "
+                                     "--confirm \"<nome do monitor>\""},
+                         indent=2, ensure_ascii=False))
+        return
+    # delete é destrutivo e irreversível — 2º fator: o nome informado em --confirm
+    # tem que bater com o nome real do monitor (snapshot). Bloqueia delete acidental
+    # por id errado.
+    if not args.confirm:
+        print(json.dumps({"error": "delete exige --confirm \"<nome do monitor>\" "
+                                   "(2º fator) além de --execute"},
+                         ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    actual_name = snapshot.get("name") if snapshot else None
+    if actual_name is None:
+        print(json.dumps({"error": f"não foi possível confirmar o monitor {args.id}: "
+                                   "snapshot indisponível (monitor pausado/ausente nos "
+                                   "metrics). Delete bloqueado por segurança."},
+                         ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    if args.confirm != actual_name:
+        print(json.dumps({"error": "nome em --confirm não bate com o monitor",
+                          "id": int(args.id), "expected": actual_name,
+                          "got": args.confirm}, ensure_ascii=False), file=sys.stderr)
+        sys.exit(1)
+    check_write_limit()
+    t0 = time.monotonic()
+    sio = _socket_session()
+    try:
+        resp = _check_ack(sio.call("deleteMonitor", int(args.id)))
+        log_event("delete", "ok", (time.monotonic() - t0) * 1000,
+                  {"source": args.source, "id": int(args.id), "name": actual_name})
+        print(json.dumps({**resp, "snapshot_before": snapshot, "dry_run": False},
+                         indent=2, ensure_ascii=False))
+    finally:
+        sio.close()
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+_MONITOR_TYPES = ["http", "port", "ping", "keyword", "json-query", "dns", "steam",
+                  "mqtt", "sqlserver", "postgres", "mysql", "mongodb", "radius",
+                  "redis", "group"]
+
+
+def _add_monitor_args(parser):
+    parser.add_argument("--type",            default="http", choices=_MONITOR_TYPES)
+    parser.add_argument("--interval",        type=int, default=60)
+    parser.add_argument("--retry-interval",  type=int, default=60)
+    parser.add_argument("--maxretries",      type=int, default=3)
+    parser.add_argument("--headers",         help='JSON string: \'{"apikey":"..."}\'')
+    parser.add_argument("--keyword",         help="Keyword to search in response body")
+    parser.add_argument("--expected-status", type=int, help="Expected HTTP status code")
+
+
+def _add_write_args(parser):
+    """Args de mutation-safety comuns a todo write: dry-run default + atribuição."""
+    parser.add_argument("--source", required=True,
+                        help="Origem da escrita: human | agent:<slug> | routine:<name>")
+    parser.add_argument("--execute", action="store_true",
+                        help="Efetivar a mutação (sem isso é dry-run — só imprime o que faria)")
+
+
+def main():
+    if not BASE_URL:
+        print(json.dumps({"error": "UPTIME_KUMA_URL not set"}))
+        sys.exit(1)
+
+    p = argparse.ArgumentParser(description="Uptime Kuma CLI")
+    p.add_argument("--max-writes", type=int, default=5,
+                   help="Limite de writes por execução (default: 5)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("smoke", help="Smoke test: auth + fetch metrics")
+
+    ps = sub.add_parser("status", help="List all monitors with current status")
+    ps.add_argument("--name", help="Filter by name (substring)")
+    ps.add_argument("--down", action="store_true", help="Show only DOWN monitors")
+
+    pg = sub.add_parser("get", help="Get one monitor by ID")
+    pg.add_argument("id")
+
+    pa = sub.add_parser("add", help="Create a new monitor")
+    pa.add_argument("name")
+    pa.add_argument("url")
+    _add_monitor_args(pa)
+    _add_write_args(pa)
+
+    pe = sub.add_parser("edit", help="Edit an existing monitor")
+    pe.add_argument("id")
+    pe.add_argument("name")
+    pe.add_argument("url")
+    _add_monitor_args(pe)
+    _add_write_args(pe)
+
+    for name, help_text in [("pause", "Pause monitor (cega o monitoramento do alvo)"),
+                            ("resume", "Resume monitor"),
+                            ("delete", "Delete monitor (IRREVERSÍVEL)")]:
+        px = sub.add_parser(name, help=help_text)
+        px.add_argument("id", help="Monitor ID")
+        _add_write_args(px)
+        if name == "delete":
+            px.add_argument("--confirm", metavar="NOME",
+                            help="2º fator obrigatório: nome exato do monitor a deletar")
+
+    args = p.parse_args()
+    global _max_writes
+    _max_writes = args.max_writes
+    {
+        "smoke":  cmd_smoke,
+        "status": cmd_status,
+        "get":    cmd_get,
+        "add":    cmd_add,
+        "edit":   cmd_edit,
+        "pause":  cmd_pause,
+        "resume": cmd_resume,
+        "delete": cmd_delete,
+    }[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py
+++ b/.claude/skills/int-uptime-kuma/scripts/uptime_kuma_client.py
@@ -122,6 +122,30 @@ def _parse_metrics(raw: str) -> list[dict]:
 
 # ── Socket.io client (WebSocket via python-socketio) ──────────────────────────
 
+def _login_hint(resp: Any) -> str:
+    """Translate a rejected login ack into an actionable diagnosis.
+
+    The two failure modes need different fixes, so the message must tell them
+    apart instead of just echoing the raw payload (the gap that made the auth
+    failure opaque): wrong/stale credentials vs. 2FA enabled on the account.
+    The raw ack is always appended so nothing is hidden.
+    """
+    raw = json.dumps(resp, ensure_ascii=False)
+    msg = (resp.get("msg") if isinstance(resp, dict) else "") or ""
+    low = msg.lower()
+    if "token" in low or "2fa" in low or "twofa" in low:
+        hint = ("2FA está ativo nesta conta — o login Socket.io exige o código TOTP "
+                "(o cliente envia token vazio). Desative o 2FA do usuário de serviço "
+                "ou use uma conta sem 2FA para a automação.")
+    elif "incorrectcreds" in low or "credential" in low or "password" in low:
+        hint = ("credenciais rejeitadas — UPTIME_KUMA_USERNAME/PASSWORD stale ou "
+                "incorretos. Confira o usuário (não é necessariamente 'admin') e a "
+                "senha no .env contra a instância.")
+    else:
+        hint = "login rejeitado pelo servidor."
+    return f"{hint} (resposta do servidor: {raw})"
+
+
 class UKSocket:
     """Socket.io client over WebSocket using python-socketio.
 
@@ -168,7 +192,7 @@ class UKSocket:
             timeout=15,
         )
         if not (isinstance(resp, dict) and resp.get("ok")):
-            raise RuntimeError(f"login failed: {json.dumps(resp)}")
+            raise RuntimeError(f"login failed: {_login_hint(resp)}")
         return resp
 
     def call(self, event: str, *args) -> Any:

--- a/.claude/skills/int-uptime-kuma/tests/conftest.py
+++ b/.claude/skills/int-uptime-kuma/tests/conftest.py
@@ -1,0 +1,113 @@
+"""conftest.py — pytest config para int-uptime-kuma.
+
+Bloqueia toda rede real (autouse). Bootstrap do módulo via path (não é package
+instalado). Padrão idêntico às skills de referência (int-blue, int-agendor).
+
+O cliente Socket.io (python-socketio) é stubado: os testes nunca abrem socket
+real. Testes do caminho de escrita usam o fake `socketio.Client` para configurar
+acks de resposta.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: importar uptime_kuma_client.py via path
+# ---------------------------------------------------------------------------
+_TESTS_DIR = Path(__file__).resolve().parent
+_SKILL_ROOT = _TESTS_DIR.parent
+_SCRIPT_PATH = _SKILL_ROOT / "scripts" / "uptime_kuma_client.py"
+
+_spec = importlib.util.spec_from_file_location("uptime_kuma_client", _SCRIPT_PATH)
+_uk = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_uk)
+sys.modules.setdefault("uptime_kuma_client", _uk)
+
+
+@pytest.fixture
+def uk():
+    """The module under test."""
+    return _uk
+
+
+# ---------------------------------------------------------------------------
+# Fixture autouse — bloqueia toda rede real + define creds/env fake
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def block_network(monkeypatch):
+    def _deny(*args, **kwargs):
+        raise RuntimeError(
+            "PROIBIDO: teste tentou abrir conexão de rede real. "
+            "Use o fake socketio ou stub _fetch_metrics."
+        )
+    monkeypatch.setattr("urllib.request.urlopen", _deny)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def fake_env(monkeypatch):
+    monkeypatch.setattr(_uk, "BASE_URL", "https://status.example.com")
+    monkeypatch.setattr(_uk, "API_KEY", "uk1_testkey")
+    monkeypatch.setattr(_uk, "USERNAME", "tester")
+    monkeypatch.setattr(_uk, "PASSWORD", "testpass")
+    yield
+
+
+@pytest.fixture(autouse=True)
+def reset_write_count(monkeypatch):
+    """O contador de writes é global no módulo — zera entre testes."""
+    monkeypatch.setattr(_uk, "_write_count", 0)
+    monkeypatch.setattr(_uk, "_max_writes", 5)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Fake python-socketio client
+# ---------------------------------------------------------------------------
+
+class FakeSioClient:
+    """Stand-in for socketio.Client. Records emits and returns scripted acks."""
+
+    # class-level scripting hooks the tests can set
+    connect_should_fail = 0          # number of leading connect() calls that raise
+    acks: dict = {}                  # event -> ack dict to return
+
+    def __init__(self, *args, **kwargs):
+        self.calls: list = []
+        FakeSioClient.last_instance = self
+
+    def connect(self, url, **kwargs):
+        if FakeSioClient.connect_should_fail > 0:
+            FakeSioClient.connect_should_fail -= 1
+            raise RuntimeError("simulated connect failure")
+        self.connected_url = url
+
+    def call(self, event, *args, **kwargs):
+        self.calls.append((event, args))
+        if event in FakeSioClient.acks:
+            return FakeSioClient.acks[event]
+        # default: success
+        return {"ok": True, "msg": "successAdded", "monitorID": 42}
+
+    def disconnect(self):
+        self.disconnected = True
+
+
+@pytest.fixture
+def fake_socketio(monkeypatch):
+    """Injects a fake `socketio` module so UKSocket.connect imports the fake."""
+    import types
+    FakeSioClient.connect_should_fail = 0
+    FakeSioClient.acks = {}
+    fake_module = types.ModuleType("socketio")
+    fake_module.Client = FakeSioClient
+    monkeypatch.setitem(sys.modules, "socketio", fake_module)
+    # make time.sleep instant so retry/backoff doesn't slow tests
+    monkeypatch.setattr(_uk.time, "sleep", lambda *a, **k: None)
+    return FakeSioClient

--- a/.claude/skills/int-uptime-kuma/tests/test_uptime_kuma_client.py
+++ b/.claude/skills/int-uptime-kuma/tests/test_uptime_kuma_client.py
@@ -333,6 +333,36 @@ class TestLogin:
         assert "connect failed" in str(e.value)
 
 
+# ── _login_hint (auth failure is actionable, not opaque) ──────────────────────
+
+class TestLoginHint:
+    def test_bad_creds_hint(self, uk):
+        h = uk._login_hint({"ok": False, "msg": "authIncorrectCreds"})
+        assert "stale" in h or "incorretos" in h
+        assert "authIncorrectCreds" in h  # raw payload preserved
+
+    def test_2fa_hint(self, uk):
+        h = uk._login_hint({"ok": False, "msg": "Token required for 2FA"})
+        assert "2FA" in h
+
+    def test_unknown_hint_keeps_raw(self, uk):
+        h = uk._login_hint({"ok": False, "msg": "weird"})
+        assert "weird" in h
+
+    def test_non_dict_hint(self, uk):
+        h = uk._login_hint(None)
+        assert "null" in h  # json.dumps(None) -> "null"
+
+    def test_login_failure_message_is_actionable(self, uk, fake_socketio):
+        """The raised error must carry the actionable hint, not just the raw ack."""
+        fake_socketio.acks["login"] = {"ok": False, "msg": "authIncorrectCreds"}
+        s = uk.UKSocket()
+        s.connect()
+        with pytest.raises(RuntimeError) as e:
+            s.login()
+        assert "stale" in str(e.value) or "incorretos" in str(e.value)
+
+
 # ── _socket_session (auth gate) ───────────────────────────────────────────────
 
 class TestSocketSession:

--- a/.claude/skills/int-uptime-kuma/tests/test_uptime_kuma_client.py
+++ b/.claude/skills/int-uptime-kuma/tests/test_uptime_kuma_client.py
@@ -1,0 +1,763 @@
+"""Tests for int-uptime-kuma client.
+
+Cobre: parser Prometheus, smoke, status/get + filtros, login (incl. regressão do
+fallback ok:true), verificação de ack (regressão do `{}` silencioso), payload de
+monitor v2 (conditions / accepted_statuscodes), e cada comando de escrita.
+
+Sem rede real (conftest bloqueia). O caminho de escrita usa o fake socketio.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def make_args(**kw):
+    """Build an argparse-like namespace with monitor-arg defaults.
+
+    Defaults para os campos de mutation-safety: execute=True (a maioria dos testes
+    de escrita exercita o caminho efetivado; testes de dry-run passam execute=False
+    explicitamente) e source válido.
+    """
+    base = dict(
+        name="Test", url="https://example.com/", type="http",
+        interval=60, retry_interval=60, maxretries=3,
+        headers=None, keyword=None, expected_status=None, id="1",
+        execute=True, source="agent:test", confirm=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+SAMPLE_METRICS = """\
+# HELP monitor_status The status of the monitor
+# TYPE monitor_status gauge
+monitor_status{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com"} 1
+monitor_status{monitor_id="2",monitor_name="Site B",monitor_type="keyword",monitor_url="https://b.com"} 0
+monitor_status{monitor_id="3",monitor_name="Grp",monitor_type="group",monitor_url="null"} 2
+monitor_response_time{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com"} 123
+monitor_uptime_ratio{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com"} 0.997
+monitor_uptime_ratio{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com",window="24"} 0.5
+monitor_cert_days_remaining{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com"} 78
+monitor_cert_is_valid{monitor_id="1",monitor_name="Site A",monitor_type="http",monitor_url="https://a.com"} 1
+monitor_cert_is_valid{monitor_id="2",monitor_name="Site B",monitor_type="keyword",monitor_url="https://b.com"} 0
+"""
+
+
+# ── Prometheus parser ─────────────────────────────────────────────────────────
+
+class TestParseMetrics:
+    def test_returns_list(self, uk):
+        assert isinstance(uk._parse_metrics(SAMPLE_METRICS), list)
+
+    def test_monitor_count(self, uk):
+        assert len(uk._parse_metrics(SAMPLE_METRICS)) == 3
+
+    def test_sorted_by_id(self, uk):
+        ids = [m["id"] for m in uk._parse_metrics(SAMPLE_METRICS)]
+        assert ids == ["1", "2", "3"]
+
+    def test_status_up(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["status"] == "UP"
+
+    def test_status_down(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "2")
+        assert m["status"] == "DOWN"
+
+    def test_status_pending(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "3")
+        assert m["status"] == "PENDING"
+
+    def test_name_extracted(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["name"] == "Site A"
+
+    def test_type_extracted(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "2")
+        assert m["type"] == "keyword"
+
+    def test_url_extracted(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["url"] == "https://a.com"
+
+    def test_response_ms(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["response_ms"] == 123
+
+    def test_uptime_24h_formatted(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["uptime_24h"] == "99.7%"
+
+    def test_windowed_uptime_skipped(self, uk):
+        # the window="24" line (0.5) must NOT override the base 0.997
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["uptime_24h"] == "99.7%"
+
+    def test_cert_days(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["cert_days"] == 78
+
+    def test_cert_valid_true(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "1")
+        assert m["cert_valid"] is True
+
+    def test_cert_valid_false(self, uk):
+        m = next(m for m in uk._parse_metrics(SAMPLE_METRICS) if m["id"] == "2")
+        assert m["cert_valid"] is False
+
+    def test_comment_lines_ignored(self, uk):
+        # HELP/TYPE comment lines must not create monitors
+        assert all(m["id"].isdigit() for m in uk._parse_metrics(SAMPLE_METRICS))
+
+    def test_empty_input(self, uk):
+        assert uk._parse_metrics("") == []
+
+    def test_unknown_metric_ignored(self, uk):
+        raw = 'some_other_metric{monitor_id="9"} 1'
+        assert uk._parse_metrics(raw) == []
+
+    def test_malformed_value_ignored(self, uk):
+        raw = 'monitor_status{monitor_id="1",monitor_name="X",monitor_type="http"} notanumber'
+        # monitor dict is created but status not set (value unparseable)
+        out = uk._parse_metrics(raw)
+        assert out and "status" not in out[0]
+
+
+# ── smoke ─────────────────────────────────────────────────────────────────────
+
+class TestSmoke:
+    @pytest.fixture(autouse=True)
+    def _stub_write_auth(self, uk, monkeypatch, request):
+        """The read-path smoke tests isolate the read path: stub write_auth to a
+        no-network PASS. The dedicated write_auth tests below opt OUT of this stub
+        (they exercise the real _smoke_write_auth via the fake socketio)."""
+        if request.function.__name__.startswith("test_smoke_write_auth"):
+            return
+        monkeypatch.setattr(
+            uk, "_smoke_write_auth",
+            lambda: {"step": "write_auth", "status": "PASS", "duration_ms": 0},
+        )
+
+    def test_smoke_pass(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["overall"] == "PASS"
+
+    def test_smoke_exit_zero_always(self, uk, monkeypatch, capsys):
+        def _boom():
+            raise RuntimeError("metrics down")
+        monkeypatch.setattr(uk, "_fetch_metrics", _boom)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0  # exit 0 even on failure (smoke contract)
+
+    def test_smoke_fail_overall_on_metrics_error(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: (_ for _ in ()).throw(RuntimeError("x")))
+        with pytest.raises(SystemExit):
+            uk.cmd_smoke()
+        out = json.loads(capsys.readouterr().out)
+        assert out["overall"] == "FAIL"
+
+    def test_smoke_json_shape(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        with pytest.raises(SystemExit):
+            uk.cmd_smoke()
+        out = json.loads(capsys.readouterr().out)
+        assert set(["overall", "steps", "duration_ms"]).issubset(out)
+        assert isinstance(out["steps"], list)
+
+    def test_smoke_missing_api_key(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "API_KEY", "")
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["overall"] == "FAIL"
+        assert out["steps"][0]["step"] == "auth"
+        assert out["steps"][0]["status"] == "FAIL"
+
+    def test_smoke_counts_down(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        with pytest.raises(SystemExit):
+            uk.cmd_smoke()
+        out = json.loads(capsys.readouterr().out)
+        fetch = next(s for s in out["steps"] if s["step"] == "fetch_metrics")
+        assert fetch["down"] == 1
+
+    # ── smoke v2: write_auth step ──────────────────────────────────────────────
+
+    def test_smoke_write_auth_pass(self, uk, monkeypatch, fake_socketio, capsys):
+        """write_auth does a real login (no mutation) and reports PASS."""
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        wa = next(s for s in out["steps"] if s["step"] == "write_auth")
+        assert wa["status"] == "PASS"
+        assert out["overall"] == "PASS"
+        # it must NOT mutate: only login was emitted
+        events = [c[0] for c in fake_socketio.last_instance.calls]
+        assert events == ["login"]
+
+    def test_smoke_write_auth_fail_sets_overall(self, uk, monkeypatch, fake_socketio, capsys):
+        """Rejected login → write_auth FAIL → overall FAIL (the Fase 1 regression)."""
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        fake_socketio.acks["login"] = {"ok": False, "msg": "authIncorrectCreds"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0  # smoke always exits 0
+        out = json.loads(capsys.readouterr().out)
+        wa = next(s for s in out["steps"] if s["step"] == "write_auth")
+        assert wa["status"] == "FAIL"
+        assert out["overall"] == "FAIL"
+
+    def test_smoke_write_auth_skip_no_creds(self, uk, monkeypatch, capsys):
+        """No write creds → SKIP, and SKIP must NOT fail overall."""
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        monkeypatch.setattr(uk, "USERNAME", "")
+        with pytest.raises(SystemExit):
+            uk.cmd_smoke()
+        out = json.loads(capsys.readouterr().out)
+        wa = next(s for s in out["steps"] if s["step"] == "write_auth")
+        assert wa["status"] == "SKIP"
+        assert out["overall"] == "PASS"  # read path fine, write skipped
+
+    def test_smoke_write_auth_skip_no_socketio(self, uk, monkeypatch, capsys):
+        """python-socketio missing → SKIP (graceful), never crash."""
+        import builtins
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        real_import = builtins.__import__
+
+        def _no_socketio(name, *a, **k):
+            if name == "socketio":
+                raise ImportError("no module named socketio")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _no_socketio)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_smoke()
+        assert e.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        wa = next(s for s in out["steps"] if s["step"] == "write_auth")
+        assert wa["status"] == "SKIP"
+
+
+# ── status / get ──────────────────────────────────────────────────────────────
+
+class TestStatusGet:
+    def test_status_all(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        uk.cmd_status(make_args(name=None, down=False))
+        assert len(json.loads(capsys.readouterr().out)) == 3
+
+    def test_status_name_filter(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        uk.cmd_status(make_args(name="site a", down=False))
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 1 and out[0]["name"] == "Site A"
+
+    def test_status_down_filter(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        uk.cmd_status(make_args(name=None, down=True))
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 1 and out[0]["status"] == "DOWN"
+
+    def test_get_found(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        uk.cmd_get(make_args(id="2"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["id"] == "2"
+
+    def test_get_not_found(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_get(make_args(id="999"))
+        assert e.value.code == 1
+        assert "not found" in capsys.readouterr().out
+
+
+# ── login (regressão: fallback ok:true) ───────────────────────────────────────
+
+class TestLogin:
+    def test_login_success(self, uk, fake_socketio):
+        fake_socketio.acks["login"] = {"ok": True, "token": "tok123"}
+        s = uk.UKSocket()
+        s.connect()
+        resp = s.login()
+        assert resp["ok"] is True
+
+    def test_login_failure_raises(self, uk, fake_socketio):
+        """REGRESSÃO: login com ok:false DEVE levantar, nunca seguir."""
+        fake_socketio.acks["login"] = {"ok": False, "msg": "authIncorrectCreds"}
+        s = uk.UKSocket()
+        s.connect()
+        with pytest.raises(RuntimeError) as e:
+            s.login()
+        assert "login failed" in str(e.value)
+        assert "authIncorrectCreds" in str(e.value)
+
+    def test_login_empty_response_raises(self, uk, fake_socketio):
+        """REGRESSÃO: resposta vazia/não-dict não vira fallback ok:true."""
+        fake_socketio.acks["login"] = {}
+        s = uk.UKSocket()
+        s.connect()
+        with pytest.raises(RuntimeError):
+            s.login()
+
+    def test_login_none_response_raises(self, uk, fake_socketio):
+        fake_socketio.acks["login"] = None
+        s = uk.UKSocket()
+        s.connect()
+        with pytest.raises(RuntimeError):
+            s.login()
+
+    def test_connect_retries_then_succeeds(self, uk, fake_socketio):
+        fake_socketio.connect_should_fail = 2
+        s = uk.UKSocket()
+        s.connect(attempts=4)  # should retry past the 2 failures
+        assert s._sio is not None
+
+    def test_connect_exhausts_retries(self, uk, fake_socketio):
+        fake_socketio.connect_should_fail = 10
+        s = uk.UKSocket()
+        with pytest.raises(RuntimeError) as e:
+            s.connect(attempts=3)
+        assert "connect failed" in str(e.value)
+
+
+# ── _socket_session (auth gate) ───────────────────────────────────────────────
+
+class TestSocketSession:
+    def test_session_exits_on_bad_login(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": False, "msg": "authIncorrectCreds"}
+        with pytest.raises(SystemExit) as e:
+            uk._socket_session()
+        assert e.value.code == 1
+        assert "authIncorrectCreds" in capsys.readouterr().out
+
+    def test_session_exits_on_missing_creds(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "USERNAME", "")
+        with pytest.raises(SystemExit) as e:
+            uk._socket_session()
+        assert e.value.code == 1
+
+    def test_session_ok_returns_socket(self, uk, fake_socketio):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        s = uk._socket_session()
+        assert isinstance(s, uk.UKSocket)
+
+
+# ── _check_ack (regressão: `{}` silencioso) ───────────────────────────────────
+
+class TestCheckAck:
+    def test_ok_passes_through(self, uk):
+        resp = {"ok": True, "monitorID": 5}
+        assert uk._check_ack(resp) == resp
+
+    def test_empty_dict_exits_nonzero(self, uk, capsys):
+        """REGRESSÃO: ack {} NÃO pode passar como sucesso."""
+        with pytest.raises(SystemExit) as e:
+            uk._check_ack({})
+        assert e.value.code == 1
+        assert "failed" in capsys.readouterr().out
+
+    def test_ok_false_exits_nonzero(self, uk, capsys):
+        with pytest.raises(SystemExit) as e:
+            uk._check_ack({"ok": False, "msg": "boom"})
+        assert e.value.code == 1
+        assert "boom" in capsys.readouterr().out
+
+    def test_non_dict_exits_nonzero(self, uk):
+        with pytest.raises(SystemExit) as e:
+            uk._check_ack("not a dict")
+        assert e.value.code == 1
+
+
+# ── _build_monitor (schema v2) ────────────────────────────────────────────────
+
+class TestBuildMonitor:
+    def test_has_conditions_field(self, uk):
+        """v2 schema: conditions é NOT NULL."""
+        m = uk._build_monitor(make_args())
+        assert m["conditions"] == []
+
+    def test_accepted_statuscodes_default_list(self, uk):
+        """o servidor itera accepted_statuscodes (.every) — deve ser lista."""
+        m = uk._build_monitor(make_args())
+        assert m["accepted_statuscodes"] == ["200-299"]
+
+    def test_accepted_statuscodes_custom(self, uk):
+        m = uk._build_monitor(make_args(expected_status=204))
+        assert m["accepted_statuscodes"] == ["204"]
+
+    def test_accepted_statuscodes_zero_not_dropped(self, uk):
+        """MEDIUM-1: expected_status=0 is a real value, not a 'use default' signal."""
+        m = uk._build_monitor(make_args(expected_status=0))
+        assert m["accepted_statuscodes"] == ["0"]
+
+    def test_basic_fields(self, uk):
+        m = uk._build_monitor(make_args(name="X", url="https://x.com"))
+        assert m["name"] == "X" and m["url"] == "https://x.com"
+        assert m["type"] == "http" and m["active"] is True
+
+    def test_interval_passthrough(self, uk):
+        m = uk._build_monitor(make_args(interval=120, maxretries=5))
+        assert m["interval"] == 120 and m["maxretries"] == 5
+
+    def test_with_id_for_edit(self, uk):
+        m = uk._build_monitor(make_args(id="7"), with_id=True)
+        assert m["id"] == 7
+
+    def test_without_id_for_add(self, uk):
+        m = uk._build_monitor(make_args())
+        assert "id" not in m
+
+    def test_headers_parsed(self, uk):
+        m = uk._build_monitor(make_args(headers='{"apikey":"abc"}'))
+        assert m["headers"] == {"apikey": "abc"}
+
+    def test_headers_invalid_json_exits(self, uk, capsys):
+        with pytest.raises(SystemExit) as e:
+            uk._build_monitor(make_args(headers="{bad json"))
+        assert e.value.code == 1
+        assert "invalid --headers" in capsys.readouterr().out
+
+    def test_keyword_set(self, uk):
+        m = uk._build_monitor(make_args(keyword='"state":"open"'))
+        assert m["keyword"] == '"state":"open"'
+
+    def test_keyword_absent_when_none(self, uk):
+        m = uk._build_monitor(make_args(keyword=None))
+        assert "keyword" not in m
+
+    def test_resend_interval_default(self, uk):
+        m = uk._build_monitor(make_args())
+        assert m["resendInterval"] == 0
+
+    def test_method_default_get(self, uk):
+        assert uk._build_monitor(make_args())["method"] == "GET"
+
+
+# ── write commands ────────────────────────────────────────────────────────────
+
+class TestWriteCommands:
+    def _ok(self, fake, event, **extra):
+        fake.acks["login"] = {"ok": True, "token": "t"}
+        fake.acks[event] = {"ok": True, **extra}
+
+    def test_add_success(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "add", monitorID=99, msg="successAdded")
+        uk.cmd_add(make_args(name="N", url="https://n.com"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["monitorID"] == 99
+
+    def test_add_emits_add_event(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "add", monitorID=1)
+        uk.cmd_add(make_args())
+        events = [c[0] for c in fake_socketio.last_instance.calls]
+        assert "add" in events
+
+    def test_add_payload_has_conditions(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "add", monitorID=1)
+        uk.cmd_add(make_args())
+        add_call = next(c for c in fake_socketio.last_instance.calls if c[0] == "add")
+        payload = add_call[1][0]
+        assert payload["conditions"] == []
+
+    def test_add_failure_exits(self, uk, fake_socketio, capsys):
+        """REGRESSÃO end-to-end: add com erro do servidor exits != 0."""
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["add"] = {"ok": False, "msg": "schema error"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_add(make_args())
+        assert e.value.code == 1
+        assert "schema error" in capsys.readouterr().out
+
+    def test_add_empty_ack_exits(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["add"] = {}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_add(make_args())
+        assert e.value.code == 1
+
+    def test_add_disconnects(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "add", monitorID=1)
+        uk.cmd_add(make_args())
+        assert getattr(fake_socketio.last_instance, "disconnected", False)
+
+    def test_add_disconnects_on_failure(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["add"] = {"ok": False}
+        with pytest.raises(SystemExit):
+            uk.cmd_add(make_args())
+        assert getattr(fake_socketio.last_instance, "disconnected", False)
+
+    def test_edit_success(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "editMonitor", msg="successEdited")
+        uk.cmd_edit(make_args(id="3"))
+        events = [c[0] for c in fake_socketio.last_instance.calls]
+        assert "editMonitor" in events
+
+    def test_edit_payload_has_id(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "editMonitor")
+        uk.cmd_edit(make_args(id="3"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "editMonitor")
+        assert call[1][0]["id"] == 3
+
+    def test_pause_success(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "pauseMonitor")
+        uk.cmd_pause(make_args(id="3"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "pauseMonitor")
+        assert call[1][0] == 3
+
+    def test_resume_success(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "resumeMonitor")
+        uk.cmd_resume(make_args(id="4"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "resumeMonitor")
+        assert call[1][0] == 4
+
+    def test_delete_success(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "5", "name": "Doomed"})
+        self._ok(fake_socketio, "deleteMonitor", msg="successDeleted")
+        uk.cmd_delete(make_args(id="5", confirm="Doomed"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "deleteMonitor")
+        assert call[1][0] == 5
+
+    def test_delete_failure_exits(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "5", "name": "Doomed"})
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["deleteMonitor"] = {"ok": False, "msg": "nope"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_delete(make_args(id="5", confirm="Doomed"))
+        assert e.value.code == 1
+
+    # HIGH-1: ack barrier must be enforced on ALL 5 writes, not just add/delete.
+    # These are non-tautological: the fake call() returns {"ok":True} by default,
+    # so an ok:false ack only exits non-zero if _check_ack actually runs. Neutralize
+    # _check_ack and these flip to exit-0 → tests fail. That's the regression guard.
+    def test_edit_failure_exits(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["editMonitor"] = {"ok": False, "msg": "edit boom"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_edit(make_args(id="3"))
+        assert e.value.code == 1
+        assert "edit boom" in capsys.readouterr().out
+
+    def test_pause_failure_exits(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["pauseMonitor"] = {"ok": False, "msg": "pause boom"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_pause(make_args(id="3"))
+        assert e.value.code == 1
+        assert "pause boom" in capsys.readouterr().out
+
+    def test_resume_failure_exits(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["resumeMonitor"] = {"ok": False, "msg": "resume boom"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_resume(make_args(id="4"))
+        assert e.value.code == 1
+        assert "resume boom" in capsys.readouterr().out
+
+    def test_pause_id_coerced_to_int(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "pauseMonitor")
+        uk.cmd_pause(make_args(id="42"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "pauseMonitor")
+        assert isinstance(call[1][0], int)
+
+
+# ── mutation-safety: dry-run default, --source, gates, snapshot, --max-writes ──
+
+class TestSourceValidation:
+    @pytest.mark.parametrize("src", ["human", "agent:kuma-gates", "routine:nightly-sync"])
+    def test_valid_sources(self, uk, src):
+        assert uk.validate_source(src) == src
+
+    @pytest.mark.parametrize("src", [None, "", "robot", "agent:", "agent:UPPER", "human ", "x;y"])
+    def test_invalid_sources_exit(self, uk, src, capsys):
+        with pytest.raises(SystemExit) as e:
+            uk.validate_source(src)
+        assert e.value.code == 1
+        assert "--source obrigatório" in capsys.readouterr().err
+
+
+class TestDryRunDefault:
+    """Sem --execute: nenhum write efetiva, nenhum socket é aberto."""
+
+    def _no_socket(self, uk, monkeypatch):
+        """Falha alta se qualquer caminho tentar abrir uma sessão de escrita."""
+        def boom():
+            raise AssertionError("dry-run NÃO pode abrir socket de escrita")
+        monkeypatch.setattr(uk, "_socket_session", boom)
+
+    def test_add_dry_run_no_socket(self, uk, monkeypatch, capsys):
+        self._no_socket(uk, monkeypatch)
+        uk.cmd_add(make_args(execute=False, name="N", url="https://n.com"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["dry_run"] is True and out["would"] == "add"
+        assert out["monitor"]["name"] == "N"
+
+    def test_edit_dry_run_no_socket(self, uk, monkeypatch, capsys):
+        self._no_socket(uk, monkeypatch)
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "3", "name": "Old"})
+        uk.cmd_edit(make_args(execute=False, id="3"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["dry_run"] is True and out["would"] == "edit"
+        assert out["snapshot_before"]["name"] == "Old"
+
+    def test_pause_dry_run_no_socket(self, uk, monkeypatch, capsys):
+        self._no_socket(uk, monkeypatch)
+        uk.cmd_pause(make_args(execute=False, id="7"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["dry_run"] is True and out["would"] == "pause" and out["id"] == 7
+        assert "warning" in out
+
+    def test_resume_dry_run_no_socket(self, uk, monkeypatch, capsys):
+        self._no_socket(uk, monkeypatch)
+        uk.cmd_resume(make_args(execute=False, id="8"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["dry_run"] is True and out["would"] == "resume" and out["id"] == 8
+
+    def test_delete_dry_run_no_socket(self, uk, monkeypatch, capsys):
+        self._no_socket(uk, monkeypatch)
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "9", "name": "Doomed"})
+        uk.cmd_delete(make_args(execute=False, id="9"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["dry_run"] is True and out["would"] == "delete"
+        assert out["snapshot_before"]["name"] == "Doomed"
+        assert "IRREVERSÍVEL" in out["warning"]
+
+    def test_dry_run_does_not_check_ack(self, uk, monkeypatch, capsys):
+        """Dry-run não chama _check_ack (não há resposta de servidor a validar)."""
+        self._no_socket(uk, monkeypatch)
+        def boom(_resp):
+            raise AssertionError("_check_ack não deve rodar em dry-run")
+        monkeypatch.setattr(uk, "_check_ack", boom)
+        uk.cmd_add(make_args(execute=False))
+        assert json.loads(capsys.readouterr().out)["dry_run"] is True
+
+    def test_dry_run_requires_source(self, uk, monkeypatch, capsys):
+        """Mesmo em dry-run, --source é validado primeiro."""
+        self._no_socket(uk, monkeypatch)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_add(make_args(execute=False, source=None))
+        assert e.value.code == 1
+
+
+class TestExecuteMutates:
+    """Com --execute: efetiva e respeita o ack-check (Fase 1 preservada)."""
+
+    def _ok(self, fake, event, **extra):
+        fake.acks["login"] = {"ok": True, "token": "t"}
+        fake.acks[event] = {"ok": True, **extra}
+
+    def test_add_execute_emits_event(self, uk, fake_socketio, capsys):
+        self._ok(fake_socketio, "add", monitorID=5)
+        uk.cmd_add(make_args(execute=True))
+        events = [c[0] for c in fake_socketio.last_instance.calls]
+        assert "add" in events
+        assert json.loads(capsys.readouterr().out)["dry_run"] is False
+
+    def test_add_execute_respects_ack(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["add"] = {"ok": False, "msg": "schema error"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_add(make_args(execute=True))
+        assert e.value.code == 1
+
+    def test_resume_execute_respects_ack(self, uk, fake_socketio, capsys):
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["resumeMonitor"] = {"ok": False, "msg": "boom"}
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_resume(make_args(execute=True, id="3"))
+        assert e.value.code == 1
+
+
+class TestDeleteGate:
+    """delete exige --execute + --confirm com o nome real do monitor (2º fator)."""
+
+    def _ok_delete(self, fake):
+        fake.acks["login"] = {"ok": True, "token": "t"}
+        fake.acks["deleteMonitor"] = {"ok": True, "msg": "successDeleted"}
+
+    def test_execute_without_confirm_blocks(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "5", "name": "Real"})
+        self._ok_delete(fake_socketio)
+        called = {"socket": False}
+        monkeypatch.setattr(uk, "_socket_session",
+                            lambda: called.__setitem__("socket", True))
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_delete(make_args(execute=True, id="5", confirm=None))
+        assert e.value.code == 1
+        assert "--confirm" in capsys.readouterr().err
+        assert called["socket"] is False  # gate barrou antes de abrir socket
+
+    def test_confirm_name_mismatch_blocks(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "5", "name": "Real"})
+        self._ok_delete(fake_socketio)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_delete(make_args(execute=True, id="5", confirm="Wrong"))
+        assert e.value.code == 1
+        assert "não bate" in capsys.readouterr().err
+
+    def test_confirm_match_allows_delete(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "5", "name": "Real"})
+        self._ok_delete(fake_socketio)
+        uk.cmd_delete(make_args(execute=True, id="5", confirm="Real"))
+        call = next(c for c in fake_socketio.last_instance.calls if c[0] == "deleteMonitor")
+        assert call[1][0] == 5
+
+    def test_no_snapshot_blocks_delete(self, uk, fake_socketio, monkeypatch, capsys):
+        """Sem snapshot (monitor pausado/ausente) o 2º fator não confirma → bloqueia."""
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: None)
+        self._ok_delete(fake_socketio)
+        with pytest.raises(SystemExit) as e:
+            uk.cmd_delete(make_args(execute=True, id="5", confirm="Whatever"))
+        assert e.value.code == 1
+        assert "snapshot indisponível" in capsys.readouterr().err
+
+
+class TestSnapshotBefore:
+    """edit/delete capturam snapshot_before via Prometheus, graceful em falha."""
+
+    def test_snapshot_finds_monitor(self, uk, monkeypatch):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        snap = uk._snapshot_monitor("2")
+        assert snap["name"] == "Site B"
+
+    def test_snapshot_missing_returns_none(self, uk, monkeypatch):
+        monkeypatch.setattr(uk, "_fetch_metrics", lambda: SAMPLE_METRICS)
+        assert uk._snapshot_monitor("999") is None
+
+    def test_snapshot_network_error_returns_none(self, uk, monkeypatch):
+        def boom():
+            raise RuntimeError("network down")
+        monkeypatch.setattr(uk, "_fetch_metrics", boom)
+        assert uk._snapshot_monitor("1") is None
+
+    def test_edit_execute_includes_snapshot(self, uk, fake_socketio, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_snapshot_monitor", lambda i: {"id": "3", "name": "Before"})
+        fake_socketio.acks["login"] = {"ok": True, "token": "t"}
+        fake_socketio.acks["editMonitor"] = {"ok": True}
+        uk.cmd_edit(make_args(execute=True, id="3"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["snapshot_before"]["name"] == "Before" and out["dry_run"] is False
+
+
+class TestMaxWrites:
+    def test_write_limit_blocks_after_max(self, uk, monkeypatch, capsys):
+        monkeypatch.setattr(uk, "_write_count", 0)
+        monkeypatch.setattr(uk, "_max_writes", 1)
+        uk.check_write_limit()  # 1st ok → count = 1
+        with pytest.raises(SystemExit) as e:
+            uk.check_write_limit()  # 2nd → over limit
+        assert e.value.code == 1
+        assert "Limite de" in capsys.readouterr().err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "watchdog>=4.0",
     "sqlparse>=0.4,<1.0",
     "jsonschema>=4.21",
+    "python-socketio[client]>=5.11",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What

New integration skill **`int-uptime-kuma`** to monitor and manage an [Uptime Kuma](https://github.com/louislam/uptime-kuma) instance from the workspace.

## Why

Uptime Kuma is a common self-hosted monitoring choice, but it has **no stable REST API** (it's Socket.io-based) and the official `uptime-kuma-api` lib only supports up to **1.23.2** — leaving 2.x users without a clean programmatic path. This skill fills that gap with an in-house client validated on **2.2.1**.

## Design

- **Read path** (`status`/`get`): Prometheus `/metrics` with Basic Auth — stateless, stdlib-only, runs on any `python3`.
- **Write path** (`add`/`edit`/`pause`/`resume`/`delete`): Socket.io over WebSocket via `python-socketio`. Real login is **verified and aborts on failure** (no silent `{ok:true}` fallback); every write requires a server ack `{ok:true}` or exits non-zero.
- **Mutation-safety** (mirrors the repo's existing conventions): **dry-run by default**, `--execute` to apply, `--source` for the audit trail, `snapshot_before` on edit/delete, blast-radius **gates** (`delete` requires `--confirm "<exact name>"`; `pause` warns it blinds monitoring), `--max-writes`.
- **`smoke`**: exit-0 + JSON `{overall, steps[], duration_ms}`, including a `write_auth` step that exercises the write-path login (so an auth break surfaces in health checks).
- **2.x compat**: injects `conditions: []` (NOT NULL in 2.x) and `accepted_statuscodes` as a list.

## Tests

**107 tests**, network fully blocked in the suite (no live calls). Covers the Prometheus parser, smoke (incl. `write_auth`), dry-run-default for all 5 writes, the ack barrier for all 5 writes, the delete 2-factor gate, snapshots, and `--max-writes`. Regressions are non-tautological (neutralizing the ack check makes them fail).

## Notes

- Adds `python-socketio[client]>=5.11` to `dependencies` (required by the write path).
- Instance URL and credentials are read **from env only** (`UPTIME_KUMA_*`) — nothing hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)