### PR TITLE
fix(obs-obsidian): corrige schema de filtro and/or/not + documenta embed de Bases

### DIFF
--- a/.claude/skills/obs-obsidian-bases/SKILL.md
+++ b/.claude/skills/obs-obsidian-bases/SKILL.md
@@ -22,10 +22,11 @@ Base files use the `.base` extension and contain valid YAML.
 # Global filters apply to ALL views in the base
 filters:
   # Can be a single filter string
-  # OR a recursive filter object with and/or/not
-  and: []
-  or: []
-  not: []
+  # OR a recursive filter object with exactly ONE key: and, or, or not
+  and:
+    - 'status == "active"'
+    - not:
+        - 'file.hasTag("archived")'
 
 # Define formula properties that can be used across all views
 formulas:
@@ -52,8 +53,9 @@ views:
     groupBy:                     # Optional: group results
       property: property_name
       direction: ASC | DESC
-    filters:                     # View-specific filters
-      and: []
+    filters:                     # View-specific filters follow the same rules
+      and:
+        - 'status == "active"'
     order:                       # Properties to display in order
       - file.name
       - property_name

--- a/.claude/skills/obs-obsidian-markdown/references/EMBEDS.md
+++ b/.claude/skills/obs-obsidian-markdown/references/EMBEDS.md
@@ -38,6 +38,13 @@
 ![[document.pdf#height=400]]
 ```
 
+## Embed Bases
+
+```markdown
+![[BaseFile.base]]
+![[BaseFile.base#View Name]]
+```
+
 ## Embed Lists
 
 ```markdown


### PR DESCRIPTION
Corrige o schema de filtro (`and`/`or`/`not`) na skill obs-obsidian-bases e documenta o embed de Bases (`.base`) em obs-obsidian-markdown/references/EMBEDS.md.

Fix genérico de skill — beneficia qualquer usuário do EvoNexus com Obsidian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document usage of Base file embeds and specific view embeds in Obsidian markdown references.