### PR TITLE
fix(brain-repo): secrets_scanner silently fails to import on Python 3.9

### DIFF
--- a/dashboard/backend/brain_repo/secrets_scanner.py
+++ b/dashboard/backend/brain_repo/secrets_scanner.py
@@ -1,5 +1,7 @@
 """Brain Repo — Secret scanner for pre-commit security checks."""
 
+from __future__ import annotations
+
 import logging
 import re
 from pathlib import Path


### PR DESCRIPTION
## Summary

`secrets_scanner.py` uses PEP 604 union syntax (`list[str] | None`) in
function signatures. Without `from __future__ import annotations`,
this syntax raises `TypeError` at **import time** on Python 3.9 —
still a common interpreter (e.g. `/usr/bin/python3` ships 3.9.x on
macOS).

The dangerous part: any caller that wraps the import/scan call in a
broad `try/except` and falls back to an empty result set on failure
loses secret-scanning coverage **silently** — no error surfaced to the
user, no log noise, just an empty findings list. That's the exact
failure mode a secret scanner exists to prevent, and it's entirely
dependent on which Python interpreter happens to be on `PATH`.

## Fix

One line: add `from __future__ import annotations` at the top of the
module, so annotations are evaluated lazily as strings. No behavior
change on 3.10+, restores compatibility with 3.9.

## Test plan

- [x] `/usr/bin/python3 --version` → `Python 3.9.6`
- [x] Before fix: `import brain_repo.secrets_scanner` under 3.9.6 raises
      `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`
- [x] After fix: same import succeeds under 3.9.6
- [x] Existing module test suite (111 tests) still passes under the
      project's normal Python 3.11 environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent import-time TypeError in secrets_scanner on Python 3.9 due to use of PEP 604 union syntax without postponed evaluation of annotations.